### PR TITLE
Add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENT Instructions
+
+This repository contains a Flutter application. When modifying Dart code or other project files:
+
+- Format Dart code by running `dart format .` before committing.
+- Run static analysis with `flutter analyze`.
+- Execute `flutter test` to run the unit/widget tests.
+- Include results of these commands in the PR Testing section. If `flutter` or `dart` is not installed, note the failure due to missing dependencies.
+- Follow conventional commit style for commit messages (e.g., `feat:`, `fix:`, `docs:`).
+


### PR DESCRIPTION
## Summary
- add AGENT instructions to help with running tests and formatting

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c1cbd004832db1da34cd5df31987