### PR TITLE
Add widget and integration tests

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -1,0 +1,22 @@
+name: Flutter CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.19.6'
+      - run: flutter pub get
+      - run: dart format --set-exit-if-changed .
+      - run: flutter analyze
+      - run: flutter test
+      - run: flutter test integration_test

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:isyfit/main.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('app loads login screen', (tester) async {
+    await tester.pumpWidget(const IsyFitApp());
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+
+    expect(find.text('IsyFit'), findsOneWidget);
+    expect(find.text('Login'), findsOneWidget);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  mocktail: ^1.0.3
+  integration_test:
+    sdk: flutter
+
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your

--- a/test/services/auth_repository_test.dart
+++ b/test/services/auth_repository_test.dart
@@ -1,0 +1,42 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:isyfit/services/auth_repository.dart';
+
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockUserCredential extends Mock implements UserCredential {}
+
+void main() {
+  late MockFirebaseAuth mockAuth;
+  late AuthRepository repository;
+
+  setUp(() {
+    mockAuth = MockFirebaseAuth();
+    repository = AuthRepository(auth: mockAuth);
+  });
+
+  test('signIn delegates to FirebaseAuth', () async {
+    final credential = MockUserCredential();
+    when(() => mockAuth.signInWithEmailAndPassword(email: 'e', password: 'p'))
+        .thenAnswer((_) async => credential);
+
+    final result = await repository.signIn('e', 'p');
+
+    expect(result, credential);
+    verify(() =>
+            mockAuth.signInWithEmailAndPassword(email: 'e', password: 'p'))
+        .called(1);
+  });
+
+  test('register delegates to FirebaseAuth', () async {
+    final credential = MockUserCredential();
+    when(() => mockAuth.createUserWithEmailAndPassword(email: 'e', password: 'p'))
+        .thenAnswer((_) async => credential);
+
+    final result = await repository.register('e', 'p');
+
+    expect(result, credential);
+    verify(() => mockAuth.createUserWithEmailAndPassword(email: 'e', password: 'p'))
+        .called(1);
+  });
+}

--- a/test/services/client_repository_test.dart
+++ b/test/services/client_repository_test.dart
@@ -1,0 +1,118 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:isyfit/services/client_repository.dart';
+
+class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockCollectionReference extends Mock implements CollectionReference<Map<String, dynamic>> {}
+class MockDocumentReference extends Mock implements DocumentReference<Map<String, dynamic>> {}
+class MockDocumentSnapshot extends Mock implements DocumentSnapshot<Map<String, dynamic>> {}
+class MockQuery extends Mock implements Query<Map<String, dynamic>> {}
+class MockQuerySnapshot extends Mock implements QuerySnapshot<Map<String, dynamic>> {}
+class MockQueryDocumentSnapshot extends Mock implements QueryDocumentSnapshot<Map<String, dynamic>> {}
+
+void main() {
+  late MockFirebaseFirestore firestore;
+  late MockFirebaseAuth auth;
+  late ClientRepository repository;
+  late MockCollectionReference collection;
+
+  setUp(() {
+    firestore = MockFirebaseFirestore();
+    auth = MockFirebaseAuth();
+    repository = ClientRepository(firestore: firestore, auth: auth);
+    collection = MockCollectionReference();
+    when(() => firestore.collection('users')).thenReturn(collection);
+  });
+
+  group('fetchClientsData', () {
+    test('returns existing client data with uid', () async {
+      final docRef = MockDocumentReference();
+      final docSnap1 = MockDocumentSnapshot();
+      final docSnap2 = MockDocumentSnapshot();
+
+      when(() => collection.doc('1')).thenReturn(docRef);
+      when(() => collection.doc('2')).thenReturn(docRef);
+      when(() => docRef.get()).thenAnswer((_) async => docSnap1).thenAnswer((_) async => docSnap2);
+      when(() => docSnap1.exists).thenReturn(true);
+      when(() => docSnap1.data()).thenReturn({'name': 'Alice'});
+      when(() => docSnap2.exists).thenReturn(false);
+
+      final result = await repository.fetchClientsData(['1', '2']);
+
+      expect(result.length, 1);
+      expect(result.first['name'], 'Alice');
+      expect(result.first['uid'], '1');
+    });
+  });
+
+  group('findClientByEmail', () {
+    test('returns first document id when found', () async {
+      final query1 = MockQuery();
+      final query2 = MockQuery();
+      final query3 = MockQuery();
+      final snapshot = MockQuerySnapshot();
+      final doc = MockQueryDocumentSnapshot();
+
+      when(() => collection.where('email', isEqualTo: 'a@test.com')).thenReturn(query1);
+      when(() => query1.where('role', isEqualTo: 'Client')).thenReturn(query2);
+      when(() => query2.limit(1)).thenReturn(query3);
+      when(() => query3.get()).thenAnswer((_) async => snapshot);
+      when(() => snapshot.docs).thenReturn([doc]);
+      when(() => doc.id).thenReturn('doc1');
+
+      final result = await repository.findClientByEmail('a@test.com');
+
+      expect(result, 'doc1');
+    });
+
+    test('returns null when no match', () async {
+      final query1 = MockQuery();
+      final query2 = MockQuery();
+      final query3 = MockQuery();
+      final snapshot = MockQuerySnapshot();
+
+      when(() => collection.where('email', isEqualTo: 'a@test.com')).thenReturn(query1);
+      when(() => query1.where('role', isEqualTo: 'Client')).thenReturn(query2);
+      when(() => query2.limit(1)).thenReturn(query3);
+      when(() => query3.get()).thenAnswer((_) async => snapshot);
+      when(() => snapshot.docs).thenReturn([]);
+
+      final result = await repository.findClientByEmail('a@test.com');
+
+      expect(result, isNull);
+    });
+  });
+
+  test('linkClientToPT updates documents', () async {
+    final ptDoc = MockDocumentReference();
+    final clientDoc = MockDocumentReference();
+
+    when(() => collection.doc('pt')).thenReturn(ptDoc);
+    when(() => collection.doc('client')).thenReturn(clientDoc);
+    when(() => ptDoc.update(any())).thenAnswer((_) async {});
+    when(() => clientDoc.update(any())).thenAnswer((_) async {});
+
+    await repository.linkClientToPT('pt', 'client');
+
+    verify(() => ptDoc.update({'clients': FieldValue.arrayUnion(['client'])})).called(1);
+    verify(() => clientDoc.update({'isSolo': false, 'supervisorPT': 'pt'})).called(1);
+  });
+
+  test('unlinkClientFromPT updates documents', () async {
+    final ptDoc = MockDocumentReference();
+    final clientDoc = MockDocumentReference();
+
+    when(() => collection.doc('pt')).thenReturn(ptDoc);
+    when(() => collection.doc('client')).thenReturn(clientDoc);
+    when(() => ptDoc.update(any())).thenAnswer((_) async {});
+    when(() => clientDoc.update(any())).thenAnswer((_) async {});
+
+    await repository.unlinkClientFromPT('pt', 'client');
+
+    verify(() => ptDoc.update({'clients': FieldValue.arrayRemove(['client'])})).called(1);
+    verify(() => clientDoc.update({'isSolo': true, 'supervisorPT': FieldValue.delete()})).called(1);
+  });
+}

--- a/test/services/user_repository_test.dart
+++ b/test/services/user_repository_test.dart
@@ -1,0 +1,63 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:isyfit/services/user_repository.dart';
+
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+class MockCollectionReference extends Mock implements CollectionReference<Map<String, dynamic>> {}
+class MockDocumentReference extends Mock implements DocumentReference<Map<String, dynamic>> {}
+class MockDocumentSnapshot extends Mock implements DocumentSnapshot<Map<String, dynamic>> {}
+class MockUser extends Mock implements User {}
+
+void main() {
+  late MockFirebaseAuth mockAuth;
+  late MockFirebaseFirestore mockFirestore;
+  late UserRepository repository;
+  late MockCollectionReference mockCollection;
+  late MockDocumentReference mockDocRef;
+  late MockDocumentSnapshot mockDocSnap;
+  late MockUser mockUser;
+
+  setUp(() {
+    mockAuth = MockFirebaseAuth();
+    mockFirestore = MockFirebaseFirestore();
+    repository = UserRepository(auth: mockAuth, firestore: mockFirestore);
+    mockCollection = MockCollectionReference();
+    mockDocRef = MockDocumentReference();
+    mockDocSnap = MockDocumentSnapshot();
+    mockUser = MockUser();
+
+    when(() => mockFirestore.collection('users')).thenReturn(mockCollection);
+    when(() => mockCollection.doc(any())).thenReturn(mockDocRef);
+    when(() => mockDocRef.get()).thenAnswer((_) async => mockDocSnap);
+  });
+
+  group('isCurrentUserPT', () {
+    test('returns false when no current user', () async {
+      when(() => mockAuth.currentUser).thenReturn(null);
+      final result = await repository.isCurrentUserPT();
+      expect(result, isFalse);
+    });
+
+    test('returns true when user role is PT', () async {
+      when(() => mockAuth.currentUser).thenReturn(mockUser);
+      when(() => mockUser.uid).thenReturn('123');
+      when(() => mockDocSnap.data()).thenReturn({'role': 'PT'});
+
+      final result = await repository.isCurrentUserPT();
+      expect(result, isTrue);
+      verify(() => mockCollection.doc('123')).called(1);
+    });
+  });
+
+  test('fetchUserProfile returns document data', () async {
+    when(() => mockDocSnap.data()).thenReturn({'name': 'John'});
+
+    final result = await repository.fetchUserProfile('u1');
+
+    expect(result, {'name': 'John'});
+    verify(() => mockCollection.doc('u1')).called(1);
+  });
+}

--- a/test/theme/app_gradients_test.dart
+++ b/test/theme/app_gradients_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/theme/app_gradients.dart';
+
+void main() {
+  test('primaryColors returns two colors', () {
+    final theme = ThemeData.light();
+    final colors = AppGradients.primaryColors(theme);
+    expect(colors.length, 2);
+    expect(colors.first, theme.colorScheme.primary);
+  });
+}

--- a/test/utils/firebase_error_translator_test.dart
+++ b/test/utils/firebase_error_translator_test.dart
@@ -1,0 +1,32 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/utils/firebase_error_translator.dart';
+
+void main() {
+  group('FirebaseErrorTranslator', () {
+    test('translates FirebaseAuthException codes', () {
+      final error = FirebaseAuthException(code: 'invalid-email');
+      expect(
+        FirebaseErrorTranslator.fromException(error),
+        'The email address is invalid.',
+      );
+    });
+
+    test('translates FirebaseException codes', () {
+      final error = FirebaseException(plugin: 'firestore', code: 'permission-denied');
+      expect(
+        FirebaseErrorTranslator.fromException(error),
+        'You do not have permission to perform this action.',
+      );
+    });
+
+    test('returns default message for unknown exceptions', () {
+      final error = Exception('unknown');
+      expect(
+        FirebaseErrorTranslator.fromException(error),
+        'An unexpected error occurred. Please try again.',
+      );
+    });
+  });
+}

--- a/test/widgets/gradient_app_bar_test.dart
+++ b/test/widgets/gradient_app_bar_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/gradient_app_bar.dart';
+
+void main() {
+  testWidgets('GradientAppBar displays title', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(appBar: GradientAppBar(title: 'Hello')),
+      ),
+    );
+
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.byType(AppBar), findsOneWidget);
+  });
+}

--- a/test/widgets/gradient_button_ffss_test.dart
+++ b/test/widgets/gradient_button_ffss_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/gradient_button_for_final_submit_screen.dart';
+
+void main() {
+  testWidgets('disabled GradientButtonFFSS shows label and icon', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GradientButtonFFSS(
+          label: 'Submit',
+          icon: Icons.send,
+          onPressed: null,
+        ),
+      ),
+    );
+
+    expect(find.text('Submit'), findsOneWidget);
+    expect(find.byIcon(Icons.send), findsOneWidget);
+  });
+}

--- a/test/widgets/gradient_button_test.dart
+++ b/test/widgets/gradient_button_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/gradient_button.dart';
+
+void main() {
+  testWidgets('GradientButton renders label and triggers callback', (tester) async {
+    bool tapped = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GradientButton(
+          label: 'Save',
+          icon: Icons.save,
+          onPressed: () => tapped = true,
+        ),
+      ),
+    );
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.byIcon(Icons.save), findsOneWidget);
+
+    await tester.tap(find.byType(GradientButton));
+    expect(tapped, isTrue);
+  });
+}

--- a/test/widgets/measurement_type_tab_bar_widget_test.dart
+++ b/test/widgets/measurement_type_tab_bar_widget_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/measurement_type_tab_bar_widget.dart';
+
+void main() {
+  testWidgets('MeasurementTypeTabBarWidget shows three tabs', (tester) async {
+    final controller = TabController(length: 3, vsync: const TestVSync());
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: MeasurementTypeTabBarWidget(tabController: controller),
+        ),
+      ),
+    );
+
+    expect(find.text('BIA'), findsOneWidget);
+    expect(find.text('USArmy'), findsOneWidget);
+    expect(find.text('Plicometro'), findsOneWidget);
+  });
+}
+
+class TestVSync implements TickerProvider {
+  const TestVSync();
+  @override
+  Ticker createTicker(TickerCallback onTick) => Ticker(onTick);
+}

--- a/test/widgets/navigation_bar_test.dart
+++ b/test/widgets/navigation_bar_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/navigation_bar.dart' as nav;
+
+void main() {
+  testWidgets('NavigationBar has five items', (tester) async {
+    int index = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: nav.NavigationBar(
+          currentIndex: index,
+          onIndexChanged: (i) => index = i,
+        ),
+      ),
+    );
+
+    expect(find.byType(BottomNavigationBarItem), findsNWidgets(5));
+    await tester.tap(find.text('Account'));
+    expect(index, 4);
+  });
+}


### PR DESCRIPTION
## Summary
- include integration_test dependency
- run integration tests in CI
- add integration test for basic app startup
- add widget tests for custom widgets
- add unit test for app gradients

## Testing
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c92e20a8832da5e6c1d2b5c54215