### PR TITLE
Add repository and widget tests

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -39,5 +39,5 @@ jobs:
       - run: flutter test
 
       # 7. Test d’integrazione
-      - name: Integration tests (linux desktop)
+      - name: Integration tests (linux desktop) -d linux
         run: flutter test integration_test

--- a/integration_test/login_flow_integration_test.dart
+++ b/integration_test/login_flow_integration_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:isyfit/services/auth_repository.dart';
+import 'package:isyfit/screens/login_screen.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class _MockAuthRepository extends Mock implements AuthRepository {}
+
+class _FakeUserCredential extends Fake implements UserCredential {}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('login flow calls signIn', (tester) async {
+    final auth = _MockAuthRepository();
+    when(() => auth.signIn(any(), any()))
+        .thenAnswer((_) async => _FakeUserCredential());
+
+    await tester
+        .pumpWidget(MaterialApp(home: LoginScreen(authRepository: auth)));
+
+    await tester.enterText(find.byType(TextField).first, 'e@e.com');
+    await tester.enterText(find.byType(TextField).at(1), 'pw');
+    await tester.tap(find.text('Login'));
+    await tester.pumpAndSettle();
+
+    verify(() => auth.signIn('e@e.com', 'pw')).called(1);
+  });
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -6,7 +6,11 @@ import 'registration/registration_screen.dart';
 import '../utils/firebase_error_translator.dart';
 
 class LoginScreen extends StatefulWidget {
-  const LoginScreen({Key? key}) : super(key: key);
+  final AuthRepository authRepository;
+
+  const LoginScreen({Key? key, AuthRepository? authRepository})
+      : authRepository = authRepository ?? AuthRepository(),
+        super(key: key);
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -15,7 +19,6 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
-  final AuthRepository _authRepo = AuthRepository();
 
   bool _isLoading = false;
 
@@ -25,7 +28,7 @@ class _LoginScreenState extends State<LoginScreen> {
     });
 
     try {
-      await _authRepo.signIn(
+      await widget.authRepository.signIn(
         _emailController.text.trim(),
         _passwordController.text.trim(),
       );
@@ -37,12 +40,10 @@ class _LoginScreenState extends State<LoginScreen> {
       );
     } on FirebaseAuthException catch (e) {
       final msg = FirebaseErrorTranslator.fromException(e);
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(msg)));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
     } catch (e) {
       final msg = FirebaseErrorTranslator.fromException(e as Exception);
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text(msg)));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
     } finally {
       setState(() {
         _isLoading = false;
@@ -130,7 +131,10 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                             child: Text(
                               'Login',
-                              style: TextStyle(fontSize: 16, color: Theme.of(context).colorScheme.onPrimary),
+                              style: TextStyle(
+                                  fontSize: 16,
+                                  color:
+                                      Theme.of(context).colorScheme.onPrimary),
                             ),
                           ),
                     const SizedBox(height: 16),

--- a/test/services/auth_repository_test.dart
+++ b/test/services/auth_repository_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/services/auth_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class _MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+class _FakeUserCredential extends Fake implements UserCredential {}
+
+void main() {
+  group('AuthRepository', () {
+    late _MockFirebaseAuth mockAuth;
+    late AuthRepository repository;
+
+    setUpAll(() {
+      registerFallbackValue(_FakeUserCredential());
+    });
+
+    setUp(() {
+      mockAuth = _MockFirebaseAuth();
+      repository = AuthRepository(auth: mockAuth);
+    });
+
+    test('signIn delegates to FirebaseAuth', () async {
+      when(() => mockAuth.signInWithEmailAndPassword(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+          )).thenAnswer((_) async => _FakeUserCredential());
+
+      await repository.signIn('mail@test.com', 'pwd');
+
+      verify(() => mockAuth.signInWithEmailAndPassword(
+            email: 'mail@test.com',
+            password: 'pwd',
+          )).called(1);
+    });
+
+    test('register delegates to FirebaseAuth', () async {
+      when(() => mockAuth.createUserWithEmailAndPassword(
+            email: any(named: 'email'),
+            password: any(named: 'password'),
+          )).thenAnswer((_) async => _FakeUserCredential());
+
+      await repository.register('x@test.com', 'secret');
+
+      verify(() => mockAuth.createUserWithEmailAndPassword(
+            email: 'x@test.com',
+            password: 'secret',
+          )).called(1);
+    });
+  });
+}

--- a/test/services/user_repository_test.dart
+++ b/test/services/user_repository_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/services/user_repository.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockFirebaseAuth extends Mock implements FirebaseAuth {}
+
+class _MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+
+class _MockCollectionReference extends Mock
+    implements CollectionReference<Map<String, dynamic>> {}
+
+class _MockDocumentReference extends Mock
+    implements DocumentReference<Map<String, dynamic>> {}
+
+class _MockDocumentSnapshot extends Mock
+    implements DocumentSnapshot<Map<String, dynamic>> {}
+
+class _MockUser extends Mock implements User {}
+
+void main() {
+  group('UserRepository', () {
+    late _MockFirebaseAuth auth;
+    late _MockFirebaseFirestore firestore;
+    late UserRepository repository;
+
+    late _MockCollectionReference collection;
+    late _MockDocumentReference docRef;
+    late _MockDocumentSnapshot snapshot;
+    late _MockUser user;
+
+    setUp(() {
+      auth = _MockFirebaseAuth();
+      firestore = _MockFirebaseFirestore();
+      repository = UserRepository(auth: auth, firestore: firestore);
+      collection = _MockCollectionReference();
+      docRef = _MockDocumentReference();
+      snapshot = _MockDocumentSnapshot();
+      user = _MockUser();
+    });
+
+    test('isCurrentUserPT returns true when role is PT', () async {
+      when(() => auth.currentUser).thenReturn(user);
+      when(() => user.uid).thenReturn('uid1');
+      when(() => firestore.collection('users')).thenReturn(collection);
+      when(() => collection.doc('uid1')).thenReturn(docRef);
+      when(() => docRef.get()).thenAnswer((_) async => snapshot);
+      when(() => snapshot.data()).thenReturn({'role': 'PT'});
+
+      final result = await repository.isCurrentUserPT();
+      expect(result, isTrue);
+    });
+
+    test('isCurrentUserPT returns false when no user', () async {
+      when(() => auth.currentUser).thenReturn(null);
+      final result = await repository.isCurrentUserPT();
+      expect(result, isFalse);
+    });
+
+    test('fetchUserProfile returns data from firestore', () async {
+      when(() => firestore.collection('users')).thenReturn(collection);
+      when(() => collection.doc('uid2')).thenReturn(docRef);
+      when(() => docRef.get()).thenAnswer((_) async => snapshot);
+      when(() => snapshot.data()).thenReturn({'name': 'Foo'});
+
+      final result = await repository.fetchUserProfile('uid2');
+      expect(result, {'name': 'Foo'});
+    });
+  });
+}

--- a/test/widgets/data_card_test.dart
+++ b/test/widgets/data_card_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/data_card.dart';
+
+void main() {
+  testWidgets('DataCard displays provided information', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DataCard(
+            title: 'Weight',
+            value: '70kg',
+            icon: Icons.scale,
+            color: Colors.blue,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Weight'), findsOneWidget);
+    expect(find.text('70kg'), findsOneWidget);
+    expect(find.byIcon(Icons.scale), findsOneWidget);
+  });
+}

--- a/test/widgets/navigation_bar_test.dart
+++ b/test/widgets/navigation_bar_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isyfit/widgets/navigation_bar.dart' as nav;
+
+void main() {
+  testWidgets('NavigationBar notifies index changes', (tester) async {
+    int selected = -1;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: nav.NavigationBar(
+            currentIndex: 0,
+            onIndexChanged: (i) => selected = i,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byIcon(Icons.fitness_center));
+    await tester.pumpAndSettle();
+
+    expect(selected, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- allow injecting AuthRepository in `LoginScreen`
- add unit tests for AuthRepository and UserRepository
- add widget tests for NavigationBar and DataCard
- add integration test for LoginScreen login flow

## Testing
- `flutter analyze`
- `flutter test`
- `flutter test integration_test` *(fails: gtk+-3.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f6038b38832d98fb9826a39386b7