### PR TITLE
Fix phone prefix field width in registration

### DIFF
--- a/lib/screens/registration/registration_PT_screen.dart
+++ b/lib/screens/registration/registration_PT_screen.dart
@@ -374,7 +374,7 @@ class _RegisterPTScreenState extends State<RegisterPTScreen> {
                     // Phone
                     Row(children: [
                       SizedBox(
-                        width: 100,
+                        width: 130,
                         child: DropdownButton2<String>(
                           value: _selectedCountryCode,
                           hint: const Text('Prefix'),
@@ -396,8 +396,10 @@ class _RegisterPTScreenState extends State<RegisterPTScreen> {
                         ),
                       ),
                       const SizedBox(width: 16),
-                      Expanded(child: _textField(_phoneController, 'Phone', Icons.phone,
-                                                  keyboard: TextInputType.phone)),
+                      SizedBox(
+                          width: 200,
+                          child: _textField(_phoneController, 'Phone', Icons.phone,
+                              keyboard: TextInputType.phone)),
                     ]),
                     const SizedBox(height: 16),
 

--- a/lib/screens/registration/registration_client_screen.dart
+++ b/lib/screens/registration/registration_client_screen.dart
@@ -451,7 +451,7 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                           Row(
                             children: [
                               SizedBox(
-                                width: 100,
+                                width: 130,
                                 child: DropdownButton2<String>(
                                   isExpanded: true,
                                   value: _selectedCountryCode,
@@ -500,7 +500,8 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                                 ),
                               ),
                               const SizedBox(width: 16),
-                              Expanded(
+                              SizedBox(
+                                width: 200,
                                 child: TextField(
                                   controller: _phoneController,
                                   keyboardType: TextInputType.phone,


### PR DESCRIPTION
## Summary
- widen dropdown for phone prefix
- narrow phone number field accordingly

## Testing
- `dart format lib/screens/registration/registration_client_screen.dart lib/screens/registration/registration_PT_screen.dart`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684842a8f938832d8143c6690f4e13ce