### PR TITLE
Enhance plan selection UI

### DIFF
--- a/integration_test/gradient_button_integration_test.dart
+++ b/integration_test/gradient_button_integration_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:isyfit/widgets/gradient_button.dart';
+import 'package:isyfit/presentation/widgets/gradient_button.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/integration_test/login_flow_integration_test.dart
+++ b/integration_test/login_flow_integration_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:isyfit/services/auth_repository.dart';
-import 'package:isyfit/screens/login_screen.dart';
+import 'package:isyfit/data/repositories/auth_repository.dart';
+import 'package:isyfit/presentation/screens/login_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 class _MockAuthRepository extends Mock implements AuthRepository {}

--- a/lib/presentation/screens/registration/plan_selection_screen.dart
+++ b/lib/presentation/screens/registration/plan_selection_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
+import 'package:isyfit/presentation/theme/app_gradients.dart';
 
 class PlanSelectionScreen extends StatelessWidget {
   const PlanSelectionScreen({Key? key}) : super(key: key);
@@ -32,7 +33,7 @@ class PlanSelectionScreen extends StatelessWidget {
           // Adatta colonne in base all’orientamento
           return OrientationBuilder(
             builder: (ctx, orientation) {
-              final crossCount = orientation == Orientation.portrait ? 1 : 2;
+              final crossCount = orientation == Orientation.portrait ? 1 : 3;
               return GridView.builder(
                 padding: const EdgeInsets.all(16),
                 itemCount: products.length,
@@ -71,26 +72,39 @@ class _PlanCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final data = doc.data();
-    return GestureDetector(
-      onTap: () => Navigator.of(context).pop(doc),
-      child: Card(
-        elevation: 6,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-        child: Padding(
+    return Material(
+      elevation: 6,
+      borderRadius: BorderRadius.circular(12),
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () => Navigator.of(context).pop(doc),
+        child: Ink(
+          decoration: BoxDecoration(
+            gradient: AppGradients.primary(theme),
+            borderRadius: BorderRadius.circular(12),
+          ),
           padding: const EdgeInsets.all(16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // Titolo
-              Text(data['name'] ?? 'Plan',
-                  style: Theme.of(context).textTheme.titleLarge),
+              Text(
+                data['name'] ?? 'Plan',
+                style: theme.textTheme.titleLarge
+                    ?.copyWith(color: theme.colorScheme.onPrimary),
+              ),
               const SizedBox(height: 8),
 
               // Descrizione
               Expanded(
-                child: Text(data['description'] ?? '',
-                    style: Theme.of(context).textTheme.bodyMedium),
+                child: Text(
+                  data['description'] ?? '',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.onPrimary),
+                ),
               ),
               const SizedBox(height: 12),
 
@@ -111,7 +125,9 @@ class _PlanCard extends StatelessWidget {
                       final interval = rec['interval'] ?? 'month';
                       return Text(
                         '€${amount.toStringAsFixed(2)} / $interval',
-                        style: Theme.of(context).textTheme.headlineMedium,
+                        style: theme.textTheme.headlineMedium?.copyWith(
+                          color: theme.colorScheme.onPrimary,
+                        ),
                       );
                     }).toList(),
                   );


### PR DESCRIPTION
## Summary
- apply Material gradient to plan cards
- switch grid to three columns when landscape

## Testing
- `dart format lib/presentation/screens/registration/plan_selection_screen.dart`
- `flutter analyze` *(fails: 231 issues found)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68484dd40ec4832db52701cd62eff602