### PR TITLE
Implement PT request workflow

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,6 +41,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
     }
     kotlinOptions { jvmTarget = '1.8' }
 
@@ -72,4 +73,8 @@ android {
 flutter {
     // percorso del sorgente Flutter rispetto a questo file
     source '../..'
+}
+
+dependencies {
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="${applicationName}"

--- a/lib/data/services/notification_service.dart
+++ b/lib/data/services/notification_service.dart
@@ -28,7 +28,7 @@ class NotificationService {
         _plugin.resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>();
 
     await androidImpl?.createNotificationChannel(_channel);
-    await androidImpl?.requestPermission();
+    await androidImpl?.requestNotificationsPermission();
     await iosImpl?.requestPermissions(alert: true, badge: true, sound: true);
   }
 

--- a/lib/data/services/notification_service.dart
+++ b/lib/data/services/notification_service.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class NotificationService {
+  NotificationService._();
+  static final NotificationService instance = NotificationService._();
+
+  final FlutterLocalNotificationsPlugin _plugin =
+      FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    const android = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const ios = DarwinInitializationSettings();
+    const settings = InitializationSettings(android: android, iOS: ios);
+    await _plugin.initialize(settings);
+  }
+
+  Future<void> showNotification(
+      {required String title, required String body}) async {
+    const androidDetails = AndroidNotificationDetails(
+      'pt_requests',
+      'PT Requests',
+      channelDescription: 'Notifications for PT client requests',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+    const iosDetails = DarwinNotificationDetails();
+    const detail =
+        NotificationDetails(android: androidDetails, iOS: iosDetails);
+    await _plugin.show(0, title, body, detail);
+  }
+}

--- a/lib/data/services/notification_service.dart
+++ b/lib/data/services/notification_service.dart
@@ -1,4 +1,10 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:isyfit/presentation/screens/notifications/pt_notifications_screen.dart';
+
+/// A tiny global key that lets us navigate from anywhere.
+final GlobalKey<NavigatorState> globalNavigatorKey = GlobalKey<NavigatorState>();
 
 class NotificationService {
   NotificationService._();
@@ -16,23 +22,36 @@ class NotificationService {
 
   int _counter = 0;
 
+  /// must be called *before* runApp()
   Future<void> init() async {
     const android = AndroidInitializationSettings('@mipmap/ic_launcher');
     const ios = DarwinInitializationSettings();
     const settings = InitializationSettings(android: android, iOS: ios);
-    await _plugin.initialize(settings);
 
-    final androidImpl =
-        _plugin.resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
-    final iosImpl =
-        _plugin.resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>();
+    await _plugin.initialize(
+      settings,
+      // foreground & background taps (UI isolate)
+      onDidReceiveNotificationResponse: _handleTap,
+      // background-isolate handler (do NOT navigate here)
+      onDidReceiveBackgroundNotificationResponse: _notificationTapBackground,
+    );
+
+    // Android / iOS runtime permissions & channel
+    final androidImpl = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    final iosImpl = _plugin.resolvePlatformSpecificImplementation<
+        IOSFlutterLocalNotificationsPlugin>();
 
     await androidImpl?.createNotificationChannel(_channel);
     await androidImpl?.requestNotificationsPermission();
     await iosImpl?.requestPermissions(alert: true, badge: true, sound: true);
   }
 
-  Future<void> showNotification({required String title, required String body}) async {
+  /// Show a high-priority banner that, when tapped, opens PTNotificationsScreen.
+  Future<void> showNotification({
+    required String title,
+    required String body,
+  }) async {
     final androidDetails = AndroidNotificationDetails(
       _channel.id,
       _channel.name,
@@ -41,7 +60,43 @@ class NotificationService {
       priority: Priority.high,
     );
     const iosDetails = DarwinNotificationDetails();
-    final detail = NotificationDetails(android: androidDetails, iOS: iosDetails);
-    await _plugin.show(_counter++, title, body, detail);
+    final detail =
+        NotificationDetails(android: androidDetails, iOS: iosDetails);
+
+    final user = FirebaseAuth.instance.currentUser;
+
+    // Use a *named* route as the payload – easy to parse later.
+    await _plugin.show(
+      _counter++,
+      title,
+      body,
+      detail,
+      payload: user?.uid, // 👈 route we’ll push on tap
+    );
   }
+
+  // ---------- private helpers ---------- //
+
+  /// Runs on the UI isolate for *all* taps except cold-start ones.
+  void _handleTap(NotificationResponse response) {
+    final payload = response.payload;
+    print('Notification tapped with payload: $payload');
+    if (payload == null) return;    
+    
+    Navigator.push(
+      globalNavigatorKey.currentContext!,
+      MaterialPageRoute(
+        builder: (context) => PTNotificationsScreen(ptId: payload),
+      ),
+    );
+  }
+
+  /// Runs on a *background* isolate (Android only). Do NOT navigate here.
+  @pragma('vm:entry-point')
+  static void _notificationTapBackground(NotificationResponse response) {
+    // keep empty or do light logging – heavy work & navigation are NOT allowed
+  }
+
+  /// Expose the plugin for `getNotificationAppLaunchDetails()` in main.dart.
+  FlutterLocalNotificationsPlugin get plugin => _plugin;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,8 @@ import 'presentation/theme/app_theme.dart';
 import 'domain/providers/auth_provider.dart';
 import 'data/services/notification_service.dart';
 
-final GlobalKey<NavigatorState> _navKey = GlobalKey<NavigatorState>();
+// Using the globalNavigatorKey from notification_service.dart
+final GlobalKey<NavigatorState> _navKey = globalNavigatorKey;
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'presentation/screens/medical_history/medical_questionnaire/questionnaire
 import 'presentation/screens/medical_history/anamnesis_screen.dart';
 import 'presentation/theme/app_theme.dart';
 import 'domain/providers/auth_provider.dart';
+import 'data/services/notification_service.dart';
 
 final GlobalKey<NavigatorState> _navKey = GlobalKey<NavigatorState>();
 Future<void> main() async {
@@ -34,6 +35,7 @@ Future<void> main() async {
     appleProvider: AppleProvider.debug,
     androidProvider: AndroidProvider.debug,
   );
+  await NotificationService.instance.init();
 
   runApp(const ProviderScope(child: IsyFitApp()));
 }
@@ -131,15 +133,16 @@ class SplashScreen extends StatefulWidget {
 class _SplashScreenState extends State<SplashScreen>
     with TickerProviderStateMixin {
   // ---------- Animazione del suggerimento "UP SWIPE" ----------
-  late final AnimationController _hintCtrl;  // bounce
+  late final AnimationController _hintCtrl; // bounce
   late final Animation<Offset> _hintAnim;
 
   // ---------- Slide dell'intero Splash ----------
-  late final AnimationController _slideCtrl; // 0 → fermo, 1 → fuori dallo schermo
+  late final AnimationController
+      _slideCtrl; // 0 → fermo, 1 → fuori dallo schermo
   late final Animation<Offset> _slideAnim;
 
-  bool _canSwipe = false;   // attivo dopo 4 s
-  double _dragStartY = 0;   // memorizza partenza gesto
+  bool _canSwipe = false; // attivo dopo 4 s
+  double _dragStartY = 0; // memorizza partenza gesto
   static const _distanceThreshold = 0.30; // 30 % altezza schermo
 
   @override
@@ -211,12 +214,14 @@ class _SplashScreenState extends State<SplashScreen>
             position: _slideAnim,
             child: GestureDetector(
               // START
-              onVerticalDragStart: (details) => _dragStartY = details.globalPosition.dy,
+              onVerticalDragStart: (details) =>
+                  _dragStartY = details.globalPosition.dy,
 
               // UPDATE — segue il dito
               onVerticalDragUpdate: (details) {
                 if (!_canSwipe) return;
-                final delta = (_dragStartY - details.globalPosition.dy).clamp(0.0, screenHeight);
+                final delta = (_dragStartY - details.globalPosition.dy)
+                    .clamp(0.0, screenHeight);
                 _slideCtrl.value = delta / screenHeight;
               },
 
@@ -224,9 +229,9 @@ class _SplashScreenState extends State<SplashScreen>
               onVerticalDragEnd: (details) {
                 if (!_canSwipe) return;
 
-                final shouldClose =
-                    _slideCtrl.value > _distanceThreshold ||
-                    (details.primaryVelocity != null && details.primaryVelocity! < -700);
+                final shouldClose = _slideCtrl.value > _distanceThreshold ||
+                    (details.primaryVelocity != null &&
+                        details.primaryVelocity! < -700);
 
                 if (shouldClose) {
                   _finishSplash();
@@ -247,7 +252,9 @@ class _SplashScreenState extends State<SplashScreen>
   // ------------------------------------------------------------
   void _finishSplash() {
     _hintCtrl.stop();
-    _slideCtrl.animateTo(1, duration: const Duration(milliseconds: 200)).then((_) {
+    _slideCtrl
+        .animateTo(1, duration: const Duration(milliseconds: 200))
+        .then((_) {
       if (mounted) {
         Navigator.of(context).pushReplacement(
           MaterialPageRoute(builder: (_) => const AuthGate()),

--- a/lib/presentation/screens/PT_dashboard.dart
+++ b/lib/presentation/screens/PT_dashboard.dart
@@ -15,10 +15,50 @@ import 'package:isyfit/presentation/screens/account/account_screen.dart';
 import 'package:isyfit/presentation/screens/isy_training/isy_training_main_screen.dart';
 import 'package:isyfit/presentation/screens/isy_check/isy_check_main_screen.dart';
 import '../../data/repositories/client_repository.dart';
+import '../notifications/pt_notifications_screen.dart';
+import '../../data/services/notification_service.dart';
 
-class PTDashboard extends StatelessWidget {
+class PTDashboard extends StatefulWidget {
   PTDashboard({Key? key}) : super(key: key);
+
+  @override
+  State<PTDashboard> createState() => _PTDashboardState();
+}
+
+class _PTDashboardState extends State<PTDashboard> {
   final ClientRepository _clientRepo = ClientRepository();
+  StreamSubscription<DocumentSnapshot>? _sub;
+  int _unread = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      _sub = FirebaseFirestore.instance
+          .collection('users')
+          .doc(user.uid)
+          .snapshots()
+          .listen((doc) {
+        final data = doc.data() as Map<String, dynamic>? ?? {};
+        final notifs =
+            List<Map<String, dynamic>>.from(data['notifications'] ?? []);
+        final count = notifs.where((n) => n['read'] == false).length;
+        if (count > _unread) {
+          NotificationService.instance.showNotification(
+              title: 'Nuova richiesta',
+              body: 'Hai nuove richieste dai clienti');
+        }
+        setState(() => _unread = count);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
 
   /// Fetch logged-in user's name
   Future<String> _fetchUserName() async {
@@ -222,6 +262,36 @@ class PTDashboard extends StatelessWidget {
     return Scaffold(
       appBar: GradientAppBar(
         title: 'PT Dashboard',
+        actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PTNotificationsScreen(ptId: user.uid),
+                ),
+              );
+            },
+            icon: Stack(
+              children: [
+                const Icon(Icons.notifications),
+                if (_unread > 0)
+                  Positioned(
+                    right: 0,
+                    top: 0,
+                    child: Container(
+                      width: 8,
+                      height: 8,
+                      decoration: const BoxDecoration(
+                        color: Colors.red,
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          )
+        ],
       ),
       body: FutureBuilder<String>(
         future: _fetchUserName(),

--- a/lib/presentation/screens/PT_dashboard.dart
+++ b/lib/presentation/screens/PT_dashboard.dart
@@ -1,22 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-
-// Your other local screens
-import 'package:isyfit/presentation/screens/isy_lab/isy_lab_main_screen.dart';
+import 'dart:async';
 import 'package:isyfit/presentation/screens/login_screen.dart';
-import 'package:isyfit/presentation/screens/measurements/measurements_home_screen.dart';
 import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
 import 'package:isyfit/presentation/widgets/isy_client_options_dialog.dart';
 import 'package:isyfit/presentation/theme/app_gradients.dart';
 import 'manage_clients_screen.dart';
-import 'package:isyfit/presentation/screens/medical_history/anamnesis_screen.dart';
-import 'package:isyfit/presentation/screens/account/account_screen.dart';
-import 'package:isyfit/presentation/screens/isy_training/isy_training_main_screen.dart';
-import 'package:isyfit/presentation/screens/isy_check/isy_check_main_screen.dart';
-import '../../data/repositories/client_repository.dart';
-import '../notifications/pt_notifications_screen.dart';
-import '../../data/services/notification_service.dart';
+import 'package:isyfit/data/repositories/client_repository.dart';
+import 'package:isyfit/presentation/screens/notifications/pt_notifications_screen.dart';
+import 'package:isyfit/data/services/notification_service.dart';
 
 class PTDashboard extends StatefulWidget {
   PTDashboard({Key? key}) : super(key: key);

--- a/lib/presentation/screens/client_dashboard.dart
+++ b/lib/presentation/screens/client_dashboard.dart
@@ -4,9 +4,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:isyfit/presentation/screens/login_screen.dart';
 import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
 
-class ClientDashboard extends StatelessWidget {
+class ClientDashboard extends StatefulWidget {
   const ClientDashboard({Key? key}) : super(key: key);
 
+  @override
+  State<ClientDashboard> createState() => _ClientDashboardState();
+}
+
+class _ClientDashboardState extends State<ClientDashboard> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -22,11 +27,11 @@ class ClientDashboard extends StatelessWidget {
         title: 'Client Dashboard',
       ),
       body: SafeArea(
-        child: FutureBuilder<DocumentSnapshot>(
-          future: FirebaseFirestore.instance
+        child: StreamBuilder<DocumentSnapshot>(
+          stream: FirebaseFirestore.instance
               .collection('users')
               .doc(user.uid)
-              .get(),
+              .snapshots(),
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
@@ -53,8 +58,28 @@ class ClientDashboard extends StatelessWidget {
             }
 
             final bool isSolo = userData['isSolo'] == true;
+            final String? reqStatus = userData['requestStatus'] as String?;
             if (isSolo) {
-              return _buildSoloCard(context);
+              return Column(
+                children: [
+                  if (reqStatus != null)
+                    Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(16.0),
+                          child: Text(
+                            reqStatus == 'pending'
+                                ? 'Request pending approval.'
+                                : 'Request $reqStatus',
+                            style: theme.textTheme.bodyMedium,
+                          ),
+                        ),
+                      ),
+                    ),
+                  _buildSoloCard(context),
+                ],
+              );
             } else {
               final ptId = userData['supervisorPT'];
               return FutureBuilder<DocumentSnapshot>(

--- a/lib/presentation/screens/notifications/pt_notifications_screen.dart
+++ b/lib/presentation/screens/notifications/pt_notifications_screen.dart
@@ -1,0 +1,113 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../..//widgets/gradient_app_bar.dart';
+
+class PTNotificationsScreen extends StatelessWidget {
+  final String ptId;
+  const PTNotificationsScreen({Key? key, required this.ptId}) : super(key: key);
+
+  Future<void> _accept(Map<String, dynamic> notif) async {
+    final clientId = notif['clientId'] as String;
+    final notifsRef = FirebaseFirestore.instance.collection('users').doc(ptId);
+    final doc = await notifsRef.get();
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    final notifs = List<Map<String, dynamic>>.from(data['notifications'] ?? []);
+    final idx = notifs.indexWhere((n) => n['id'] == notif['id']);
+    if (idx >= 0) {
+      notifs[idx]['status'] = 'accepted';
+      notifs[idx]['read'] = true;
+    }
+    await notifsRef.update({
+      'notifications': notifs,
+      'clients': FieldValue.arrayUnion([clientId]),
+    });
+    await FirebaseFirestore.instance.collection('users').doc(clientId).update({
+      'isSolo': false,
+      'supervisorPT': ptId,
+      'requestStatus': 'accepted',
+    });
+  }
+
+  Future<void> _reject(Map<String, dynamic> notif) async {
+    final clientId = notif['clientId'] as String;
+    final notifsRef = FirebaseFirestore.instance.collection('users').doc(ptId);
+    final doc = await notifsRef.get();
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    final notifs = List<Map<String, dynamic>>.from(data['notifications'] ?? []);
+    final idx = notifs.indexWhere((n) => n['id'] == notif['id']);
+    if (idx >= 0) {
+      notifs[idx]['status'] = 'rejected';
+      notifs[idx]['read'] = true;
+    }
+    await notifsRef.update({'notifications': notifs});
+    await FirebaseFirestore.instance.collection('users').doc(clientId).update({
+      'requestStatus': 'rejected',
+    });
+  }
+
+  Future<void> _delete(Map<String, dynamic> notif) async {
+    final notifsRef = FirebaseFirestore.instance.collection('users').doc(ptId);
+    final doc = await notifsRef.get();
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    final notifs = List<Map<String, dynamic>>.from(data['notifications'] ?? []);
+    notifs.removeWhere((n) => n['id'] == notif['id']);
+    await notifsRef.update({'notifications': notifs});
+  }
+
+  Widget _buildTile(BuildContext context, Map<String, dynamic> n) {
+    final status = n['status'] ?? 'pending';
+    return Card(
+      child: ListTile(
+        title: Text('${n['clientName']} ${n['clientSurname']}'),
+        subtitle: Text('Status: $status'),
+        trailing: status == 'pending'
+            ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check, color: Colors.green),
+                    onPressed: () => _accept(n),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close, color: Colors.red),
+                    onPressed: () => _reject(n),
+                  ),
+                ],
+              )
+            : IconButton(
+                icon: const Icon(Icons.delete),
+                onPressed: () => _delete(n),
+              ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const GradientAppBar(title: 'Notifications'),
+      body: StreamBuilder<DocumentSnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('users')
+            .doc(ptId)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final data = snapshot.data?.data() as Map<String, dynamic>? ?? {};
+          final notifs =
+              List<Map<String, dynamic>>.from(data['notifications'] ?? []);
+          if (notifs.isEmpty) {
+            return const Center(child: Text('No notifications'));
+          }
+          return ListView(
+            padding: const EdgeInsets.all(12),
+            children: [for (final n in notifs) _buildTile(context, n)],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/notifications/pt_notifications_screen.dart
+++ b/lib/presentation/screens/notifications/pt_notifications_screen.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
-import '../..//widgets/gradient_app_bar.dart';
+import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
 
 class PTNotificationsScreen extends StatelessWidget {
   final String ptId;

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,8 +14,6 @@ import firebase_auth
 import firebase_core
 import firebase_storage
 import flutter_local_notifications
-  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
-import flutter_local_notifications
 import path_provider_foundation
 import printing
 import shared_preferences_foundation

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import firebase_app_check
 import firebase_auth
 import firebase_core
 import firebase_storage
+import flutter_local_notifications
 import path_provider_foundation
 import printing
 import shared_preferences_foundation
@@ -28,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,8 @@ import firebase_auth
 import firebase_core
 import firebase_storage
 import flutter_local_notifications
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+import flutter_local_notifications
 import path_provider_foundation
 import printing
 import shared_preferences_foundation

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "214e6f07e2a44f45972e0365c7b537eaeaddb4598db0778dd4ac64b4acd3f5b1"
+      sha256: dda4fd7909a732a014239009aa52537b136f8ce568de23c212587097887e2307
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.55"
+    version: "1.3.56"
   analyzer:
     dependency: transitive
     description:
@@ -205,26 +205,26 @@ packages:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: d25c956be5261c14bc9a69c9662de8addb308376b4b53a64469aade52e7b02f8
+      sha256: "80cafe016ea12e4b76737487784dc659720065705445be547d2f47aaaa3f2874"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.8"
+    version: "5.6.9"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
-      sha256: ee2b8f8c602ede36073afd3741e99cfea9dd982b4a44833daf665134d151c32a
+      sha256: "9c5adf444b6e4eca15ecbc497678fba6d9944041fbf22810b756269ddefa75c7"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.8"
+    version: "6.6.9"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
-      sha256: b99bc4f1f70787f694b73bc6fce238d4d6cc822c9b31ba8ef1578b180b6f77bc
+      sha256: "884c153ac66cdef469ca5e55bf71d979c3b53dc20a4c1662fae5c07bf603d878"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.8"
+    version: "4.4.9"
   code_builder:
     dependency: transitive
     description:
@@ -281,6 +281,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   dropdown_button2:
     dependency: "direct main"
     description:
@@ -341,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: file_selector_macos
-      sha256: "271ab9986df0c135d45c3cdb6bd0faa5db6f4976d3e4b437cf7d0f258d941bfc"
+      sha256: "8c9250b2bd2d8d4268e39c82543bacbaca0fda7d29e0728c3c4bbb7c820fd711"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4+2"
+    version: "0.9.4+3"
   file_selector_platform_interface:
     dependency: transitive
     description:
@@ -365,58 +373,58 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_app_check
-      sha256: a1a5255b8d19e22f2d7e9ff1a1138268cd74d2c12b31dcb487612a371d7a21e9
+      sha256: "09dccc2f132312d9749dd2fe887e307b413066e664aac45cce3d95cebe50e8ae"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2+6"
+    version: "0.3.2+7"
   firebase_app_check_platform_interface:
     dependency: transitive
     description:
       name: firebase_app_check_platform_interface
-      sha256: "26c0eca776d5d5ffb727435b71243a00e74000bd2760792921999b04564aaf59"
+      sha256: a468aba05b43f7e427fe8151aa61d97d24812ef4dd5d6bd175473c8881be46af
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1+6"
+    version: "0.1.1+7"
   firebase_app_check_web:
     dependency: transitive
     description:
       name: firebase_app_check_web
-      sha256: "889838c053f024572ba8077cb5a380ff8b224827090a1e5878f004290303ae0e"
+      sha256: "8c9ef22679402e1cecdcfd4d20e87a6dd7e1c99cfc4f0a8abf38db625d39a9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0+10"
+    version: "0.2.0+11"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
-      sha256: "10cd3f00a247f33b0a5c77574011a87379432bf3fec77a500b55f2bcc30ddd8b"
+      sha256: "10ddd766bd3d3baf1cc8fed544ef83a2c0e6027514a020e56114212ffe1036f2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.4"
+    version: "5.6.0"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: "2d15872a8899b0459fab6b4c148fd142e135acfc8a303d383d80b455e4dba7bd"
+      sha256: fde52352bfd553f5e38239b868e1e6fe6c1a6af542f5cc547554c61fef30b99b
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.3"
+    version: "7.7.0"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: efba45393050ca03d992eae1d305d5fc8c0c9f5980624053512e935c23767c4f
+      sha256: "33a0e6521a1c8c476949cc4f2f7b7d9ed8f99514b08dd905fdb9546d2391e5d9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.3"
+    version: "5.15.0"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "8cfe3c900512399ce8d50fcc817e5758ff8615eeb6fa5c846a4cc47bbf6353b6"
+      sha256: "420d9111dcf095341f1ea8fdce926eef750cf7b9745d21f38000de780c94f608"
       url: "https://pub.dev"
     source: hosted
-    version: "3.13.1"
+    version: "3.14.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -437,26 +445,26 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_storage
-      sha256: "4c1438da319c7599d974dcc4290ed2685a44f614355d1e9fbf516fcb404543b0"
+      sha256: a14390edb4b7a119297ddd09773421233ffddcfa1f8dcb670d9ce71672fdb624
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.6"
+    version: "12.4.7"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
       name: firebase_storage_platform_interface
-      sha256: "4be3b79079abb7708e041ed0178afb57ddb41cf0d77258c19a6befb057925e9d"
+      sha256: d6c7a32c714cd7d59b61a5c610137695547986b8a5abe71aaf71197d6d255006
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.6"
+    version: "5.2.7"
   firebase_storage_web:
     dependency: transitive
     description:
       name: firebase_storage_web
-      sha256: eb7890f7fcfcb47db9f9ed0c9260b99cfb5e3cc1cafd7dd9bfeea5471c148966
+      sha256: "45ad71124862ef6d3a68770edc0aaefb854c0b4781aa96e9b0ec10400af03861"
       url: "https://pub.dev"
     source: hosted
-    version: "3.10.13"
+    version: "3.10.14"
   fixnum:
     dependency: transitive
     description:
@@ -491,6 +499,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: edae0c34573233ab03f5ba1f07465e55c384743893042cb19e010b4ee8541c12
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.3.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: f8fc0652a601f83419d623c85723a3e82ad81f92b33eaa9bcc21ea1b94773e6e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_pdfview:
     dependency: "direct main"
     description:
@@ -1164,6 +1204,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.3"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   timing:
     dependency: transitive
     description:
@@ -1264,10 +1312,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   web:
     dependency: transitive
     description:
@@ -1320,10 +1368,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_platform_interface
-      sha256: "7cb32b21825bd65569665c32bb00a34ded5779786d6201f5350979d2d529940d"
+      sha256: f0dc2dc3a2b1e3a6abdd6801b9355ebfeb3b8f6cde6b9dc7c9235909c4a1f147
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   webview_flutter_wkwebview:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.13.0"
   barcode:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -197,23 +197,31 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   cloud_firestore:
     dependency: "direct main"
     description:
       name: cloud_firestore
-      sha256: "80cafe016ea12e4b76737487784dc659720065705445be547d2f47aaaa3f2874"
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "5.6.9"
-  cloud_firestore_platform_interface:
+    version: "1.19.1"
+  dbus:
     dependency: transitive
     description:
-      name: cloud_firestore_platform_interface
-      sha256: "9c5adf444b6e4eca15ecbc497678fba6d9944041fbf22810b756269ddefa75c7"
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+    version: "1.3.3"
+    description:
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+    version: "7.0.1"
       url: "https://pub.dev"
     source: hosted
     version: "6.6.9"
@@ -468,6 +476,38 @@ packages:
   fixnum:
     dependency: transitive
     description:
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: edae0c34573233ab03f5ba1f07465e55c384743893042cb19e010b4ee8541c12
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.3.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: f8fc0652a601f83419d623c85723a3e82ad81f92b33eaa9bcc21ea1b94773e6e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
       url: "https://pub.dev"
@@ -698,23 +738,23 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+2"
-  image_picker_platform_interface:
-    dependency: transitive
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+    version: "10.0.9"
     description:
-      name: image_picker_platform_interface
-      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+    version: "3.0.9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.1"
-  image_picker_windows:
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+    version: "0.12.17"
     dependency: transitive
     description:
-      name: image_picker_windows
-      sha256: "6ad07afc4eb1bc25f3a01084d28520496c4a3bb0cb13685435838167c9dcedeb"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+    version: "1.16.0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1+1"
-  integration_test:
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+    version: "1.9.1"
     dependency: "direct dev"
     description: flutter
     source: sdk
@@ -874,12 +914,12 @@ packages:
   path_provider_android:
     dependency: transitive
     description:
-      name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+    version: "3.1.6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
-  path_provider_foundation:
+      sha256: "107d8be718f120bbba9dcd1e95e3bd325b1b4a4f07db64154635ba03f2567a0d"
+    version: "5.0.3"
     dependency: transitive
     description:
       name: path_provider_foundation
@@ -1047,27 +1087,35 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
-  shared_preferences_platform_interface:
-    dependency: transitive
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+    version: "1.10.1"
     description:
-      name: shared_preferences_platform_interface
-      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+    version: "1.12.1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
-  shared_preferences_web:
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+    version: "2.1.4"
     dependency: transitive
     description:
-      name: shared_preferences_web
-      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+    version: "1.4.1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
-  shared_preferences_windows:
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+    version: "1.2.2"
     dependency: transitive
     description:
-      name: shared_preferences_windows
-      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+    version: "0.10.1"
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
@@ -1231,12 +1279,12 @@ packages:
   url_launcher:
     dependency: "direct main"
     description:
-      name: url_launcher
-      sha256: "9d06212b1362abc2f0f0d78e6f09f726608c74e3b9462e8368bb03314aa8d603"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+    version: "15.0.0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
-  url_launcher_android:
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+    version: "3.1.0"
     dependency: transitive
     description:
       name: url_launcher_android
@@ -1340,7 +1388,7 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
-  webdriver:
+  dart: ">=3.7.0-0 <4.0.0"
     dependency: transitive
     description:
       name: webdriver

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   app_links: ^6.4.0
   flutter_stripe: ^11.5.0
   flutter_riverpod: ^2.6.1
+  flutter_local_notifications: ^19.3.0
 
   # --- NUOVO: runtime per il builder usato ---
   json_annotation: ^4.9.0         # ← NEW

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -14,6 +14,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -15,6 +15,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   flutter_local_notifications_windows
+  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -15,7 +15,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   flutter_local_notifications_windows
-  flutter_local_notifications_windows
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## Summary
- allow clients to request a PT without instant linking
- store pending requests and notify PT via local notifications
- add notification service
- show notification badge in PT dashboard
- display request status on client dashboard

## Testing
- `dart format` executed
- `flutter analyze` reported 226 issues (mostly style)
- `flutter test` passed

------
https://chatgpt.com/codex/tasks/task_e_685821deb35c832d8648b3535dc83687