### PR TITLE
Add password reset functionality

### DIFF
--- a/lib/data/repositories/auth_repository.dart
+++ b/lib/data/repositories/auth_repository.dart
@@ -19,4 +19,9 @@ class AuthRepository {
       password: password,
     );
   }
+
+  /// Send a password reset email to the given address.
+  Future<void> sendPasswordReset(String email) {
+    return _auth.sendPasswordResetEmail(email: email);
+  }
 }

--- a/lib/data/repositories/auth_repository.dart
+++ b/lib/data/repositories/auth_repository.dart
@@ -24,4 +24,14 @@ class AuthRepository {
   Future<void> sendPasswordReset(String email) {
     return _auth.sendPasswordResetEmail(email: email);
   }
+
+  /// Verify a password reset code sent via email and return the associated email.
+  Future<String> verifyResetCode(String code) {
+    return _auth.verifyPasswordResetCode(code);
+  }
+
+  /// Confirm the password reset with the given code and new password.
+  Future<void> confirmPasswordReset(String code, String newPassword) {
+    return _auth.confirmPasswordReset(code: code, newPassword: newPassword);
+  }
 }

--- a/lib/data/repositories/auth_repository.dart
+++ b/lib/data/repositories/auth_repository.dart
@@ -34,4 +34,16 @@ class AuthRepository {
   Future<void> confirmPasswordReset(String code, String newPassword) {
     return _auth.confirmPasswordReset(code: code, newPassword: newPassword);
   }
+
+  /// Update password for the current user.
+  Future<void> updatePassword(String newPassword) {
+    final user = _auth.currentUser;
+    if (user == null) {
+      throw FirebaseAuthException(
+        code: 'no-user',
+        message: 'No user is currently signed in.',
+      );
+    }
+    return user.updatePassword(newPassword);
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'firebase_options.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'presentation/screens/login_screen.dart';
+import 'presentation/screens/reset_password_screen.dart';
 import 'presentation/screens/base_screen.dart';
 import 'presentation/screens/medical_history/medical_questionnaire/questionnaire_screen.dart';
 import 'presentation/screens/medical_history/anamnesis_screen.dart';
@@ -84,6 +85,16 @@ class _IsyFitAppState extends State<IsyFitApp> {
         if (ctx != null) {
           ScaffoldMessenger.of(ctx).showSnackBar(
             const SnackBar(content: Text('Pagamento annullato')),
+          );
+        }
+        break;
+      case 'reset': // isyfit://reset?oobCode=abc
+        final code = uri.queryParameters['oobCode'];
+        if (code != null && code.isNotEmpty) {
+          _navKey.currentState?.push(
+            MaterialPageRoute(
+              builder: (_) => ResetPasswordScreen(actionCode: code),
+            ),
           );
         }
         break;

--- a/lib/presentation/screens/forgot_password_screen.dart
+++ b/lib/presentation/screens/forgot_password_screen.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../../data/repositories/auth_repository.dart';
+import '../widgets/gradient_app_bar.dart';
+import '../../domain/utils/firebase_error_translator.dart';
+
+class ForgotPasswordScreen extends StatefulWidget {
+  final AuthRepository authRepository;
+
+  ForgotPasswordScreen({Key? key, AuthRepository? authRepository})
+      : authRepository = authRepository ?? AuthRepository(),
+        super(key: key);
+
+  @override
+  State<ForgotPasswordScreen> createState() => _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  bool _isLoading = false;
+
+  Future<void> _sendReset() async {
+    setState(() {
+      _isLoading = true;
+    });
+    try {
+      await widget.authRepository.sendPasswordReset(
+        _emailController.text.trim(),
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Email di reset inviata. Controlla la tua casella.'),
+        ),
+      );
+      Navigator.pop(context);
+    } on FirebaseAuthException catch (e) {
+      final msg = FirebaseErrorTranslator.fromException(e);
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: const GradientAppBar(title: 'Reset Password'),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TextField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                decoration: InputDecoration(
+                  labelText: 'Email',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12.0),
+                  ),
+                  prefixIcon: Icon(
+                    Icons.email,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              _isLoading
+                  ? const CircularProgressIndicator()
+                  : ElevatedButton(
+                      onPressed: _sendReset,
+                      style: ElevatedButton.styleFrom(
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12.0),
+                        ),
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 12.0,
+                          horizontal: 24.0,
+                        ),
+                      ),
+                      child: Text(
+                        'Invia Email',
+                        style: TextStyle(
+                          fontSize: 16,
+                          color: theme.colorScheme.onPrimary,
+                        ),
+                      ),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -34,6 +34,7 @@ class _LoginScreenState extends State<LoginScreen> {
         _passwordController.text.trim(),
       );
 
+      if (!mounted) return;
       // Navigate to BaseScreen on success:
       Navigator.pushReplacement(
         context,
@@ -41,14 +42,24 @@ class _LoginScreenState extends State<LoginScreen> {
       );
     } on FirebaseAuthException catch (e) {
       final msg = FirebaseErrorTranslator.fromException(e);
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(msg)),
+        );
+      }
     } catch (e) {
       final msg = FirebaseErrorTranslator.fromException(e as Exception);
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(msg)),
+        );
+      }
     } finally {
-      setState(() {
-        _isLoading = false;
-      });
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
     }
   }
 

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -90,8 +90,8 @@ class _LoginScreenState extends State<LoginScreen> {
                     constraints: BoxConstraints(
                       maxWidth: cardWidth,
                       minHeight: isPortrait
-                          ? constraints.maxHeight * 0.4
-                          : constraints.maxHeight * 0.70, // card più alta
+                          ? constraints.maxHeight * 0.35
+                          : constraints.maxHeight * 0.40, // card più alta
                     ),
                     child: Padding(
                       padding: const EdgeInsets.all(24.0),
@@ -147,27 +147,6 @@ class _LoginScreenState extends State<LoginScreen> {
                             ),
                           ),
                           const SizedBox(height: 16),
-                          Center(
-                            child: TextButton(
-                              onPressed: () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) =>
-                                        ForgotPasswordScreen(),
-                                  ),
-                                );
-                              },
-                              child: Text(
-                                'Password dimenticata?',
-                                style: theme.textTheme.bodyMedium?.copyWith(
-                                  color: theme.colorScheme.primary,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                          const SizedBox(height: 24),
 
                           // Login Button al centro
                           _isLoading
@@ -196,6 +175,27 @@ class _LoginScreenState extends State<LoginScreen> {
                                 ),
                           const SizedBox(height: 16),
 
+                          Center(
+                            child: TextButton(
+                              onPressed: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) =>
+                                        ForgotPasswordScreen(),
+                                  ),
+                                );
+                              },
+                              child: Text(
+                                'Password dimenticata?',
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.primary,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
+
                           // Redirect alla registrazione al centro
                           Center(
                             child: TextButton(
@@ -209,7 +209,7 @@ class _LoginScreenState extends State<LoginScreen> {
                                 );
                               },
                               child: Text(
-                                'Non sei registrato? Clicca qui',
+                                'Non sei registrato? Registrati ora!',
                                 style: theme.textTheme.bodyMedium?.copyWith(
                                   color: theme.colorScheme.primary,
                                   fontWeight: FontWeight.bold,

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -73,7 +73,7 @@ class _LoginScreenState extends State<LoginScreen> {
           builder: (context, constraints) {
             final isPortrait =
                 MediaQuery.of(context).orientation == Orientation.portrait;
-            final widthFactor = isPortrait ? 0.9 : 0.6;
+            final widthFactor = isPortrait ? 0.8 : 0.6;
             final cardWidth =
                 (constraints.maxWidth * widthFactor).clamp(320.0, 500.0);
 

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../data/repositories/auth_repository.dart';
 import 'package:isyfit/presentation/screens/base_screen.dart';
 import 'registration/registration_screen.dart';
+import 'forgot_password_screen.dart';
 import '../../domain/utils/firebase_error_translator.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -85,8 +86,10 @@ class _LoginScreenState extends State<LoginScreen> {
                       padding: const EdgeInsets.all(24.0),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
-                        mainAxisAlignment: MainAxisAlignment.center, // elementi centrati verticalmente
-                        crossAxisAlignment: CrossAxisAlignment.center, // elementi centrati orizzontalmente
+                        mainAxisAlignment: MainAxisAlignment
+                            .center, // elementi centrati verticalmente
+                        crossAxisAlignment: CrossAxisAlignment
+                            .center, // elementi centrati orizzontalmente
                         children: [
                           // Logo (rimane a sinistra per mantenere il branding)
                           Align(
@@ -132,6 +135,27 @@ class _LoginScreenState extends State<LoginScreen> {
                               ),
                             ),
                           ),
+                          const SizedBox(height: 16),
+                          Center(
+                            child: TextButton(
+                              onPressed: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) =>
+                                        ForgotPasswordScreen(),
+                                  ),
+                                );
+                              },
+                              child: Text(
+                                'Password dimenticata?',
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.primary,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ),
                           const SizedBox(height: 24),
 
                           // Login Button al centro
@@ -142,7 +166,8 @@ class _LoginScreenState extends State<LoginScreen> {
                                     onPressed: _login,
                                     style: ElevatedButton.styleFrom(
                                       shape: RoundedRectangleBorder(
-                                        borderRadius: BorderRadius.circular(12.0),
+                                        borderRadius:
+                                            BorderRadius.circular(12.0),
                                       ),
                                       padding: const EdgeInsets.symmetric(
                                         vertical: 12.0,

--- a/lib/presentation/screens/reset_password_screen.dart
+++ b/lib/presentation/screens/reset_password_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../../data/repositories/auth_repository.dart';
+import '../widgets/gradient_app_bar.dart';
+import '../../domain/utils/firebase_error_translator.dart';
+
+class ResetPasswordScreen extends StatefulWidget {
+  final String actionCode;
+  final AuthRepository authRepository;
+
+  ResetPasswordScreen(
+      {Key? key, required this.actionCode, AuthRepository? authRepository})
+      : authRepository = authRepository ?? AuthRepository(),
+        super(key: key);
+
+  @override
+  State<ResetPasswordScreen> createState() => _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
+  final TextEditingController _pwdController = TextEditingController();
+  final TextEditingController _confirmController = TextEditingController();
+  bool _isLoading = false;
+  bool _showInfo = false;
+
+  bool get _hasUpper => _pwdController.text.contains(RegExp(r'[A-Z]'));
+  bool get _hasLower => _pwdController.text.contains(RegExp(r'[a-z]'));
+  bool get _hasNumber => _pwdController.text.contains(RegExp(r'[0-9]'));
+  bool get _hasSpecial =>
+      _pwdController.text.contains(RegExp(r'[!@#\\$%^&*(),.?\\":{}|<>]'));
+  bool get _hasLen => _pwdController.text.length >= 8;
+  bool get _pwdOk =>
+      _hasUpper && _hasLower && _hasNumber && _hasSpecial && _hasLen;
+
+  Future<void> _resetPassword() async {
+    if (!_pwdOk) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Password not strong enough.")),
+      );
+      return;
+    }
+    if (_pwdController.text != _confirmController.text) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Passwords do not match.")),
+      );
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      await widget.authRepository.confirmPasswordReset(
+        widget.actionCode,
+        _pwdController.text.trim(),
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Password updated successfully")),
+      );
+      Navigator.of(context).pushNamedAndRemoveUntil('/login', (route) => false);
+    } on FirebaseAuthException catch (e) {
+      final msg = FirebaseErrorTranslator.fromException(e);
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(msg)));
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  Widget _pwdRow(String txt, bool ok) => Row(
+        children: [
+          Icon(ok ? Icons.check_circle : Icons.cancel,
+              color: ok ? Colors.green : Colors.red, size: 18),
+          const SizedBox(width: 6),
+          Text(txt, style: TextStyle(color: ok ? Colors.green : Colors.red)),
+        ],
+      );
+
+  @override
+  void dispose() {
+    _pwdController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Theme.of(context);
+    return Scaffold(
+      appBar: const GradientAppBar(title: 'Reset Password'),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
+          child: Card(
+            elevation: 8,
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: _pwdController,
+                    obscureText: true,
+                    onChanged: (_) => setState(() {}),
+                    decoration: InputDecoration(
+                      labelText: 'New Password',
+                      border: const OutlineInputBorder(),
+                      prefixIcon:
+                          Icon(Icons.lock, color: t.colorScheme.primary),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: _confirmController,
+                    obscureText: true,
+                    decoration: InputDecoration(
+                      labelText: 'Confirm Password',
+                      border: const OutlineInputBorder(),
+                      prefixIcon:
+                          Icon(Icons.lock, color: t.colorScheme.primary),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: IconButton(
+                      icon: Icon(Icons.info_outline,
+                          color: _pwdOk ? Colors.green : Colors.red),
+                      onPressed: () => setState(() => _showInfo = !_showInfo),
+                    ),
+                  ),
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 300),
+                    child: _showInfo
+                        ? Container(
+                            key: const ValueKey('info'),
+                            margin: const EdgeInsets.only(top: 8),
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: t.colorScheme.surfaceVariant,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                _pwdRow('≥ 8 characters', _hasLen),
+                                _pwdRow('1 uppercase', _hasUpper),
+                                _pwdRow('1 lowercase', _hasLower),
+                                _pwdRow('1 number', _hasNumber),
+                                _pwdRow('1 special', _hasSpecial),
+                              ],
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                  const SizedBox(height: 24),
+                  _isLoading
+                      ? const CircularProgressIndicator()
+                      : ElevatedButton(
+                          onPressed: _resetPassword,
+                          style: ElevatedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 32, vertical: 14),
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(12)),
+                          ),
+                          child: const Text('Reset Password'),
+                        ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow sending Firebase password reset emails
- create a `ForgotPasswordScreen`
- link password reset from login screen

## Testing
- `dart format lib/data/repositories/auth_repository.dart lib/presentation/screens/login_screen.dart lib/presentation/screens/forgot_password_screen.dart`
- `flutter analyze` *(231 issues found)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_685a8e654394832da441132f866cb72d