### PR TITLE
Add PT info to request status

### DIFF
--- a/lib/presentation/constants/layout_constants.dart
+++ b/lib/presentation/constants/layout_constants.dart
@@ -1,0 +1,3 @@
+const double kBottomBarHeight = 64.0;
+const double kFabSize = 72.0;
+const double kScreenBottomPadding = kBottomBarHeight + kFabSize / 2;

--- a/lib/presentation/screens/account/account_screen.dart
+++ b/lib/presentation/screens/account/account_screen.dart
@@ -7,6 +7,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:isyfit/presentation/screens/base_screen.dart';
 import 'package:isyfit/presentation/screens/login_screen.dart';
 import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
+import 'package:isyfit/presentation/constants/layout_constants.dart';
 
 //TODO: implement the settings part here
 
@@ -283,6 +284,7 @@ class _AccountScreenState extends State<AccountScreen> {
         ],
       ),
       body: SingleChildScrollView(
+        padding: const EdgeInsets.only(bottom: kScreenBottomPadding),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
@@ -565,7 +567,7 @@ class _AccountScreenState extends State<AccountScreen> {
         ],
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16.0),
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, kScreenBottomPadding),
         child: Column(
           children: [
             /// 1) A bigger "profile" card with tinted surface

--- a/lib/presentation/screens/account/account_screen.dart
+++ b/lib/presentation/screens/account/account_screen.dart
@@ -38,7 +38,8 @@ class _AccountScreenState extends State<AccountScreen> {
   bool _isEditMode = false;
 
   // --- PT linking state ---
-  bool _isSolo = true;
+  bool _isSolo = false;
+  String? _role;
   String? _requestStatus;
   String? _requestedPt;
   String? _requestedPtEmail;
@@ -85,7 +86,8 @@ class _AccountScreenState extends State<AccountScreen> {
             _dateOfBirth = DateTime.tryParse(data['dateOfBirth']);
           }
           _profileImageUrl = data['profileImageUrl'];
-          _isSolo = data['isSolo'] ?? true;
+          _role = data['role'];
+          _isSolo = data['role'] == 'Client' && data['isSolo'] == true;
           _requestStatus = data['requestStatus'];
           _requestedPt = data['requestedPT'];
           _requestedPtEmail = null;
@@ -476,7 +478,7 @@ class _AccountScreenState extends State<AccountScreen> {
   }
 
   Widget _buildPtLinkCard(BuildContext context) {
-    if (!_isSolo) return const SizedBox.shrink();
+    if (!_isSolo || _role != 'Client') return const SizedBox.shrink();
     final theme = Theme.of(context);
 
     if (_requestStatus == 'pending') {

--- a/lib/presentation/screens/account/account_screen.dart
+++ b/lib/presentation/screens/account/account_screen.dart
@@ -485,17 +485,19 @@ class _AccountScreenState extends State<AccountScreen> {
 
     if (_requestStatus == 'pending') {
       return Card(
+        elevation: 4,
         margin: const EdgeInsets.symmetric(horizontal: 16),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.all(20),
           child: Row(
             children: [
-              const Icon(Icons.hourglass_top, color: Colors.orange),
+              const Icon(Icons.hourglass_top, color: Colors.orange, size: 32),
               const SizedBox(width: 12),
               Expanded(
                 child: Text(
                   _requestedPtEmail != null
-                      ? 'Awaiting approval from \$_requestedPtEmail'
+                      ? 'Awaiting approval from $_requestedPtEmail'
                       : 'Link request pending approval.',
                   style: theme.textTheme.bodyMedium,
                 ),
@@ -507,22 +509,42 @@ class _AccountScreenState extends State<AccountScreen> {
     }
 
     return Card(
+      elevation: 4,
       margin: const EdgeInsets.symmetric(horizontal: 16),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: const EdgeInsets.all(20),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            Row(
+              children: [
+                Icon(Icons.person_add,
+                    color: theme.colorScheme.primary, size: 32),
+                const SizedBox(width: 12),
+                Text(
+                  'Connect with a Personal Trainer',
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
             if (_requestStatus == 'rejected')
               Padding(
                 padding: const EdgeInsets.only(bottom: 8.0),
                 child: Text(
                   _requestedPtEmail != null
-                      ? 'Request to \$_requestedPtEmail was rejected. You can send a new one.'
+                      ? 'Request to $_requestedPtEmail was rejected. You can send a new one.'
                       : 'Previous request was rejected. You can send a new one.',
                   style: TextStyle(color: theme.colorScheme.error),
                 ),
               ),
+            Text(
+              'Enter your trainer\'s email to send a link request.',
+              style: theme.textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
             TextField(
               controller: _ptEmailController,
               decoration: const InputDecoration(

--- a/lib/presentation/screens/client_dashboard.dart
+++ b/lib/presentation/screens/client_dashboard.dart
@@ -173,7 +173,8 @@ class _ClientDashboardState extends State<ClientDashboard> {
                               .get()
                           : Future.value(null),
                       builder: (context, ptSnap) {
-                        final email = ptSnap.data?.data()?['email'] as String?;
+                        final data = ptSnap.data?.data() as Map<String, dynamic>?;
+                        final email = data?['email'] as String?;
                         return _buildRequestStatusCard(reqStatus, email);
                       },
                     ),

--- a/lib/presentation/screens/client_dashboard.dart
+++ b/lib/presentation/screens/client_dashboard.dart
@@ -157,7 +157,8 @@ class _ClientDashboardState extends State<ClientDashboard> {
               );
             }
 
-            final bool isSolo = userData['isSolo'] == true;
+            final bool isSolo =
+                userData['role'] == 'Client' && userData['isSolo'] == true;
             final String? reqStatus = userData['requestStatus'] as String?;
             final String? requestedPt = userData['requestedPT'] as String?;
             if (isSolo) {

--- a/lib/presentation/screens/client_dashboard.dart
+++ b/lib/presentation/screens/client_dashboard.dart
@@ -159,24 +159,12 @@ class _ClientDashboardState extends State<ClientDashboard> {
 
             final bool isSolo = userData['isSolo'] == true;
             final String? reqStatus = userData['requestStatus'] as String?;
+            final String? requestedPt = userData['requestedPT'] as String?;
             if (isSolo) {
               return Column(
                 children: [
                   if (reqStatus != null)
-                    Padding(
-                      padding: const EdgeInsets.all(12.0),
-                      child: Card(
-                        child: Padding(
-                          padding: const EdgeInsets.all(16.0),
-                          child: Text(
-                            reqStatus == 'pending'
-                                ? 'Request pending approval.'
-                                : 'Request $reqStatus',
-                            style: theme.textTheme.bodyMedium,
-                          ),
-                        ),
-                      ),
-                    ),
+                    _buildRequestStatusCard(reqStatus, requestedPt),
                   _buildSoloCard(context),
                 ],
               );
@@ -261,6 +249,58 @@ class _ClientDashboardState extends State<ClientDashboard> {
                 ),
               ],
             ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRequestStatusCard(String status, String? ptId) {
+    final theme = Theme.of(context);
+    IconData icon;
+    Color color;
+    String text;
+    String? ptEmail;
+    if (ptId != null) {
+      FirebaseFirestore.instance
+          .collection('users')
+          .doc(ptId)
+          .get()
+          .then((doc) {
+        setState(() {
+          ptEmail = doc.data()?['email'];
+        });
+      });
+    }
+    if (status == 'pending') {
+      icon = Icons.hourglass_top;
+      color = Colors.orange;
+      text = ptEmail != null
+          ? 'Awaiting approval from \$ptEmail'
+          : 'Link request pending approval.';
+    } else {
+      icon = Icons.cancel;
+      color = theme.colorScheme.error;
+      text = ptEmail != null
+          ? 'Request to \$ptEmail was rejected. You can send a new one from the Account screen.'
+          : 'Link request rejected. You can send a new request from the Account screen.';
+    }
+    return Padding(
+      padding: const EdgeInsets.all(12.0),
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Row(
+            children: [
+              Icon(icon, color: color),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  text,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/presentation/screens/client_dashboard.dart
+++ b/lib/presentation/screens/client_dashboard.dart
@@ -66,7 +66,7 @@ class _ClientDashboardState extends State<ClientDashboard> {
           (_lastNotifiedMs == null || latest > _lastNotifiedMs!)) {
         NotificationService.instance.showNotification(
           title: 'Nuova notifica',
-          body: 'Il tuo PT ha aggiornato le notifiche',
+          body: 'Il tuo PT ha aggiornato lo stato della tua richiesta.',
           target: NotificationTarget.client,
         );
         _lastNotifiedMs = latest;

--- a/lib/presentation/screens/registration/registration_client_screen.dart
+++ b/lib/presentation/screens/registration/registration_client_screen.dart
@@ -6,6 +6,7 @@ import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
 import '../../widgets/country_codes.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 import '../base_screen.dart';
+import 'package:isyfit/presentation/constants/layout_constants.dart';
 
 import "../../../domain/utils/firebase_error_translator.dart";
 
@@ -405,6 +406,7 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
       ),
       body: Center(
         child: SingleChildScrollView(
+          padding: const EdgeInsets.only(bottom: kScreenBottomPadding),
           child: Column(
             children: [
               /// The main Card container


### PR DESCRIPTION
## Summary
- fetch PT email when loading account data
- show pending/rejected request messages with PT email in Account screen and dashboard

## Testing
- `dart format lib/presentation/screens/account/account_screen.dart lib/presentation/screens/client_dashboard.dart`
- `flutter analyze` *(fails: 238 issues)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68611953e000832dad9369ca089268b8