### PR TITLE
Add password confirmation and email validation

### DIFF
--- a/lib/domain/utils/validators.dart
+++ b/lib/domain/utils/validators.dart
@@ -1,0 +1,4 @@
+bool isValidEmail(String email) {
+  final regex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+  return regex.hasMatch(email.trim());
+}

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -4,6 +4,7 @@ import '../../data/repositories/auth_repository.dart';
 import 'package:isyfit/presentation/screens/base_screen.dart';
 import 'registration/registration_screen.dart';
 import '../../domain/utils/firebase_error_translator.dart';
+import '../../domain/utils/validators.dart';
 
 class LoginScreen extends StatefulWidget {
   final AuthRepository authRepository;
@@ -22,6 +23,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
   bool _isLoading = false;
   bool _forgotMode = false;
+  bool _obscurePassword = true;
+
+  bool get _isEmailValid => isValidEmail(_emailController.text.trim());
 
   Future<void> _login() async {
     setState(() {
@@ -29,6 +33,13 @@ class _LoginScreenState extends State<LoginScreen> {
     });
 
     try {
+      if (!_isEmailValid) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please enter a valid email.')),
+        );
+        setState(() => _isLoading = false);
+        return;
+      }
       await widget.authRepository.signIn(
         _emailController.text.trim(),
         _passwordController.text.trim(),
@@ -68,6 +79,13 @@ class _LoginScreenState extends State<LoginScreen> {
       _isLoading = true;
     });
     try {
+      if (!_isEmailValid) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please enter a valid email.')),
+        );
+        setState(() => _isLoading = false);
+        return;
+      }
       await widget.authRepository.sendPasswordReset(
         _emailController.text.trim(),
       );
@@ -162,7 +180,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             // Password Field
                             TextField(
                               controller: _passwordController,
-                              obscureText: true,
+                              obscureText: _obscurePassword,
                               decoration: InputDecoration(
                                 labelText: 'Password',
                                 border: OutlineInputBorder(
@@ -171,6 +189,13 @@ class _LoginScreenState extends State<LoginScreen> {
                                 prefixIcon: Icon(
                                   Icons.lock,
                                   color: theme.colorScheme.primary,
+                                ),
+                                suffixIcon: IconButton(
+                                  icon: Icon(_obscurePassword
+                                      ? Icons.visibility
+                                      : Icons.visibility_off),
+                                  onPressed: () => setState(() =>
+                                      _obscurePassword = !_obscurePassword),
                                 ),
                               ),
                             ),


### PR DESCRIPTION
## Summary
- add `validators.dart` with email validation helper
- improve login with email validation and password toggle
- update client and PT registration forms with confirm password logic
- refine PT client management registration dialog with validations

## Testing
- `dart format .`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68613f7ff0c8832d95528501943311f4