### PR TITLE
Add confirm password feedback widget

### DIFF
--- a/lib/domain/utils/validators.dart
+++ b/lib/domain/utils/validators.dart
@@ -1,0 +1,4 @@
+bool isValidEmail(String email) {
+  final regex = RegExp(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$');
+  return regex.hasMatch(email.trim());
+}

--- a/lib/presentation/screens/forgot_password_screen.dart
+++ b/lib/presentation/screens/forgot_password_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../../data/repositories/auth_repository.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../../domain/utils/firebase_error_translator.dart';
+import '../../domain/utils/validators.dart';
 
 class ForgotPasswordScreen extends StatefulWidget {
   final AuthRepository authRepository;
@@ -17,9 +18,29 @@ class ForgotPasswordScreen extends StatefulWidget {
 
 class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   final TextEditingController _emailController = TextEditingController();
+  final FocusNode _emailNode = FocusNode();
+  bool _emailTouched = false;
   bool _isLoading = false;
 
+  bool get _isEmailValid => isValidEmail(_emailController.text.trim());
+
+  @override
+  void initState() {
+    super.initState();
+    _emailNode.addListener(() {
+      if (!_emailNode.hasFocus) {
+        setState(() => _emailTouched = true);
+      }
+    });
+  }
+
   Future<void> _sendReset() async {
+    if (!_isEmailValid) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a valid email.')),
+      );
+      return;
+    }
     setState(() {
       _isLoading = true;
     });
@@ -49,6 +70,7 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   @override
   void dispose() {
     _emailController.dispose();
+    _emailNode.dispose();
     super.dispose();
   }
 
@@ -99,17 +121,35 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
                             ),
                           ),
                           const SizedBox(height: 24),
-                          TextField(
-                            controller: _emailController,
-                            keyboardType: TextInputType.emailAddress,
-                            decoration: InputDecoration(
-                              labelText: 'Email',
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12.0),
-                              ),
-                              prefixIcon: Icon(
-                                Icons.email,
-                                color: theme.colorScheme.primary,
+                          Focus(
+                            onFocusChange: (hasFocus) {
+                              if (!hasFocus) {
+                                setState(() => _emailTouched = true);
+                              }
+                            },
+                            child: TextField(
+                              controller: _emailController,
+                              focusNode: _emailNode,
+                              keyboardType: TextInputType.emailAddress,
+                              decoration: InputDecoration(
+                                labelText: 'Email',
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(12.0),
+                                ),
+                                prefixIcon: Icon(
+                                  Icons.email,
+                                  color: theme.colorScheme.primary,
+                                ),
+                                suffixIcon: _emailTouched
+                                    ? Icon(
+                                        _isEmailValid
+                                            ? Icons.check_circle
+                                            : Icons.cancel,
+                                        color: _isEmailValid
+                                            ? Colors.green
+                                            : Colors.red,
+                                      )
+                                    : null,
                               ),
                             ),
                           ),

--- a/lib/presentation/screens/login_screen.dart
+++ b/lib/presentation/screens/login_screen.dart
@@ -4,6 +4,7 @@ import '../../data/repositories/auth_repository.dart';
 import 'package:isyfit/presentation/screens/base_screen.dart';
 import 'registration/registration_screen.dart';
 import '../../domain/utils/firebase_error_translator.dart';
+import '../../domain/utils/validators.dart';
 
 class LoginScreen extends StatefulWidget {
   final AuthRepository authRepository;
@@ -22,6 +23,9 @@ class _LoginScreenState extends State<LoginScreen> {
 
   bool _isLoading = false;
   bool _forgotMode = false;
+  bool _obscurePassword = true;
+
+  bool get _isEmailValid => isValidEmail(_emailController.text.trim());
 
   Future<void> _login() async {
     setState(() {
@@ -29,6 +33,13 @@ class _LoginScreenState extends State<LoginScreen> {
     });
 
     try {
+      if (!_isEmailValid) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please enter a valid email.')),
+        );
+        setState(() => _isLoading = false);
+        return;
+      }
       await widget.authRepository.signIn(
         _emailController.text.trim(),
         _passwordController.text.trim(),
@@ -68,6 +79,13 @@ class _LoginScreenState extends State<LoginScreen> {
       _isLoading = true;
     });
     try {
+      if (!_isEmailValid) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Please enter a valid email.')),
+        );
+        setState(() => _isLoading = false);
+        return;
+      }
       await widget.authRepository.sendPasswordReset(
         _emailController.text.trim(),
       );
@@ -162,7 +180,7 @@ class _LoginScreenState extends State<LoginScreen> {
                             // Password Field
                             TextField(
                               controller: _passwordController,
-                              obscureText: true,
+                              obscureText: _obscurePassword,
                               decoration: InputDecoration(
                                 labelText: 'Password',
                                 border: OutlineInputBorder(
@@ -171,6 +189,13 @@ class _LoginScreenState extends State<LoginScreen> {
                                 prefixIcon: Icon(
                                   Icons.lock,
                                   color: theme.colorScheme.primary,
+                                ),
+                                suffixIcon: IconButton(
+                                  icon: Icon(_obscurePassword
+                                      ? Icons.visibility
+                                      : Icons.visibility_off),
+                                  onPressed: () => setState(() =>
+                                      _obscurePassword = !_obscurePassword),
                                 ),
                               ),
                             ),

--- a/lib/presentation/screens/manage_clients_screen.dart
+++ b/lib/presentation/screens/manage_clients_screen.dart
@@ -10,6 +10,7 @@ import 'package:isyfit/presentation/widgets/gradient_app_bar.dart';
 import 'package:isyfit/presentation/widgets/isy_client_options_dialog.dart';
 
 import "../../domain/utils/firebase_error_translator.dart";
+import '../../domain/utils/validators.dart';
 
 enum ClientSortOption {
   nameAsc,
@@ -471,7 +472,12 @@ class _ManageClientsScreenState extends State<ManageClientsScreen> {
   }
 
   Future<void> _checkEmailAndProceed(String email) async {
-    if (email.isEmpty) return;
+    if (email.isEmpty || !isValidEmail(email)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a valid email.')),
+      );
+      return;
+    }
 
     try {
       final user = FirebaseAuth.instance.currentUser;
@@ -506,6 +512,12 @@ class _ManageClientsScreenState extends State<ManageClientsScreen> {
         final TextEditingController nameCtrl = TextEditingController();
         final TextEditingController surnameCtrl = TextEditingController();
         final TextEditingController passCtrl = TextEditingController();
+        final TextEditingController confirmCtrl = TextEditingController();
+        final FocusNode confirmNode = FocusNode();
+        bool confirmTouched = false;
+        bool showConfirmInfo = false;
+        bool obscurePass = true;
+        bool obscureConfirm = true;
         final TextEditingController phoneCtrl = TextEditingController();
         String? selectedGender;
         DateTime? selectedDOB;
@@ -528,6 +540,36 @@ class _ManageClientsScreenState extends State<ManageClientsScreen> {
                   if (picked != null) {
                     setStateDialog(() => selectedDOB = picked);
                   }
+                }
+
+                confirmNode.addListener(() {
+                  if (!confirmNode.hasFocus) {
+                    setStateDialog(() => confirmTouched = true);
+                  }
+                });
+
+                Widget confirmInfo() {
+                  return AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 300),
+                    child: showConfirmInfo &&
+                            confirmTouched &&
+                            passCtrl.text != confirmCtrl.text
+                        ? Container(
+                            key: const ValueKey('confirm_info'),
+                            width: double.infinity,
+                            margin: const EdgeInsets.only(top: 8),
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Theme.of(ctx2).colorScheme.surfaceVariant,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: const Text(
+                              'Le due password non corrispondono',
+                              style: TextStyle(color: Colors.red),
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  );
                 }
 
                 return Column(
@@ -610,13 +652,59 @@ class _ManageClientsScreenState extends State<ManageClientsScreen> {
                     const SizedBox(height: 12),
                     TextField(
                       controller: passCtrl,
-                      obscureText: true,
-                      decoration: const InputDecoration(
+                      obscureText: obscurePass,
+                      onChanged: (_) => setStateDialog(() {}),
+                      decoration: InputDecoration(
                         labelText: 'Temporary Password',
-                        border: OutlineInputBorder(),
-                        prefixIcon: Icon(Icons.lock),
+                        border: const OutlineInputBorder(),
+                        prefixIcon: const Icon(Icons.lock),
+                        suffixIcon: IconButton(
+                          icon: Icon(obscurePass
+                              ? Icons.visibility
+                              : Icons.visibility_off),
+                          onPressed: () =>
+                              setStateDialog(() => obscurePass = !obscurePass),
+                        ),
                       ),
                     ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      controller: confirmCtrl,
+                      focusNode: confirmNode,
+                      obscureText: obscureConfirm,
+                      onChanged: (_) => setStateDialog(() {}),
+                      decoration: InputDecoration(
+                        labelText: 'Confirm Password',
+                        border: const OutlineInputBorder(),
+                        prefixIcon: const Icon(Icons.lock_outline),
+                        suffixIcon: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (confirmTouched)
+                              GestureDetector(
+                                onTap: () => setStateDialog(
+                                    () => showConfirmInfo = !showConfirmInfo),
+                                child: Icon(
+                                  passCtrl.text == confirmCtrl.text
+                                      ? Icons.check_circle
+                                      : Icons.cancel,
+                                  color: passCtrl.text == confirmCtrl.text
+                                      ? Colors.green
+                                      : Colors.red,
+                                ),
+                              ),
+                            IconButton(
+                              icon: Icon(obscureConfirm
+                                  ? Icons.visibility
+                                  : Icons.visibility_off),
+                              onPressed: () => setStateDialog(
+                                  () => obscureConfirm = !obscureConfirm),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    confirmInfo(),
                     const SizedBox(height: 12),
                     TextField(
                       controller: phoneCtrl,
@@ -651,6 +739,14 @@ class _ManageClientsScreenState extends State<ManageClientsScreen> {
                             icon: const Icon(Icons.app_registration),
                             label: const Text('Register'),
                             onPressed: () {
+                              if (passCtrl.text.trim() !=
+                                  confirmCtrl.text.trim()) {
+                                ScaffoldMessenger.of(ctx2).showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Passwords do not match.')),
+                                );
+                                return;
+                              }
                               Navigator.pop(ctx2);
                               _registerClient(
                                 email: email,
@@ -724,10 +820,15 @@ class _ManageClientsScreenState extends State<ManageClientsScreen> {
     required String? gender,
     required DateTime? dob,
   }) async {
-    if (email.isEmpty || name.isEmpty || surname.isEmpty || password.isEmpty) {
+    if (email.isEmpty ||
+        !isValidEmail(email) ||
+        name.isEmpty ||
+        surname.isEmpty ||
+        password.isEmpty) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Please fill all fields.')),
+          const SnackBar(
+              content: Text('Please fill all fields with valid data.')),
         );
       }
       return;


### PR DESCRIPTION
## Summary
- shift confirm password check icon left of visibility toggle
- show error details when mismatched for client registration
- apply same logic in PT registration and client management dialog
- validate emails before sending PT link requests, password resets or linking new clients
- **align mismatch info container width with password info box**

## Testing
- `dart format .`
- `flutter analyze` *(with warnings)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68613f7ff0c8832d95528501943311f4