### PR TITLE
Add shadow and adaptive label color to radial menu

### DIFF
--- a/lib/presentation/widgets/radial_menu.dart
+++ b/lib/presentation/widgets/radial_menu.dart
@@ -87,7 +87,8 @@ class _RadialMenuState extends State<RadialMenu>
     );
     final pair = RadialMenu._items[index];
     final icon = pair.$1;
-    final label = pair.$2;      return Transform.translate(
+    final label = pair.$2;
+    return Transform.translate(
       offset: offset,
       child: Opacity(
         opacity: progress,
@@ -97,20 +98,32 @@ class _RadialMenuState extends State<RadialMenu>
             mainAxisSize: MainAxisSize.min,
             children: [
               Material(
+                elevation: 4,
                 shape: const CircleBorder(),
                 color: Colors.white,
+                shadowColor: Colors.black.withOpacity(0.3),
                 child: Padding(
                   padding: const EdgeInsets.all(12),
                   child: Icon(icon, size: 28),
                 ),
               ),
               const SizedBox(height: 4),
-              Text(
-                label,                style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  color: Colors.black,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w500,
-                ),
+              Builder(
+                builder: (context) {
+                  final bg = Theme.of(context).scaffoldBackgroundColor;
+                  final brightness = ThemeData.estimateBrightnessForColor(bg);
+                  final labelColor = brightness == Brightness.dark
+                      ? Colors.white
+                      : Colors.black;
+                  return Text(
+                    label,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: labelColor,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w500,
+                        ),
+                  );
+                },
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- add a Material elevation and shadow under radial menu icons
- adjust label color based on background brightness

## Testing
- `dart format lib/presentation/widgets/radial_menu.dart`
- `flutter analyze` *(fails: 245 issues found)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68616ddd4ba8832d82af01864ffbf37c