### PR TITLE
Improve registration screens

### DIFF
--- a/lib/presentation/screens/registration/registration_PT_screen.dart
+++ b/lib/presentation/screens/registration/registration_PT_screen.dart
@@ -270,24 +270,22 @@ class _RegisterPTScreenState extends State<RegisterPTScreen> {
         ],
       );
 
-  Widget _genderOpt(String g, IconData icn) {
-    final c = Theme.of(context).colorScheme;
+  Widget _genderOpt(String g, IconData icn, Color color) {
     final sel = _gender == g;
-    return GestureDetector(
-      onTap: () => setState(() => _gender = g),
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: sel ? c.primary : Colors.grey),
-          color: sel ? c.primary.withOpacity(.15) : Colors.transparent,
-        ),
-        child: Row(mainAxisSize: MainAxisSize.min, children: [
-          Icon(icn, color: sel ? c.primary : Colors.grey),
-          const SizedBox(width: 8),
-          Text(g, style: TextStyle(color: sel ? c.primary : Colors.grey)),
-        ]),
+    return ChoiceChip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icn, color: sel ? Colors.white : color),
+          const SizedBox(width: 6),
+          Text(g),
+        ],
       ),
+      selected: sel,
+      selectedColor: color,
+      backgroundColor: Colors.grey.shade200,
+      labelStyle: TextStyle(color: sel ? Colors.white : color),
+      onSelected: (_) => setState(() => _gender = g),
     );
   }
 
@@ -334,22 +332,36 @@ class _RegisterPTScreenState extends State<RegisterPTScreen> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     // Name & Surname
-                    Row(children: [
-                      Expanded(
-                          child: _textField(
-                              _nameController, 'Name', Icons.person)),
-                      const SizedBox(width: 16),
-                      Expanded(
-                          child: _textField(_surnameController, 'Surname',
-                              Icons.person_outline)),
-                    ]),
+                    LayoutBuilder(
+                      builder: (context, constraints) {
+                        final wide = constraints.maxWidth > 360;
+                        final nameField = Expanded(
+                            child: _textField(
+                                _nameController, 'Name', Icons.person));
+                        final surnameField = Expanded(
+                            child: _textField(_surnameController, 'Surname',
+                                Icons.person_outline));
+                        if (wide) {
+                          return Row(children: [
+                            nameField,
+                            const SizedBox(width: 16),
+                            surnameField,
+                          ]);
+                        }
+                        return Column(children: [
+                          nameField,
+                          const SizedBox(height: 16),
+                          surnameField,
+                        ]);
+                      },
+                    ),
                     const SizedBox(height: 16),
 
                     // Gender
                     Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                      _genderOpt('Male', Icons.male),
+                      _genderOpt('Male', Icons.male, Colors.blue),
                       const SizedBox(width: 16),
-                      _genderOpt('Female', Icons.female),
+                      _genderOpt('Female', Icons.female, Colors.pink),
                     ]),
                     const SizedBox(height: 16),
 
@@ -477,11 +489,25 @@ class _RegisterPTScreenState extends State<RegisterPTScreen> {
                     // Phone
                     Row(children: [
                       Expanded(
-                        flex: 2, // Takes 2/5 of the available space
-                        child: DropdownButton2<String>(
+                        flex: 2,
+                        child: DropdownButtonFormField2<String>(
                           value: _selectedCountryCode,
-                          hint: const Text('Prefix'),
-                          isExpanded: true,
+                          decoration: InputDecoration(
+                            labelText: 'Prefix',
+                            border: outline,
+                            prefixIcon: Padding(
+                              padding: const EdgeInsets.all(10),
+                              child: Text(
+                                countryCodes
+                                    .firstWhere(
+                                        (c) =>
+                                            c['code'] == _selectedCountryCode,
+                                        orElse: () => {'flag': '🌐'})['flag']!
+                                    .toString(),
+                                style: const TextStyle(fontSize: 18),
+                              ),
+                            ),
+                          ),
                           items: [
                             for (final c in countryCodes)
                               DropdownMenuItem(
@@ -494,25 +520,14 @@ class _RegisterPTScreenState extends State<RegisterPTScreen> {
                                 ]),
                               ),
                           ],
-                          selectedItemBuilder: (ctx) => countryCodes.map((c) {
-                            return Row(
-                              children: [
-                                Text(c['flag']!,
-                                    style: const TextStyle(fontSize: 18)),
-                                const SizedBox(width: 6),
-                                Text(c['code']!),
-                              ],
-                            );
-                          }).toList(),
                           onChanged: (v) =>
                               setState(() => _selectedCountryCode = v),
-                          buttonStyleData: const ButtonStyleData(height: 48),
                           dropdownStyleData: DropdownStyleData(width: 250),
                         ),
                       ),
                       const SizedBox(width: 16),
                       Expanded(
-                        flex: 3, // Takes 3/5 of the available space
+                        flex: 3,
                         child: _textField(
                             _phoneController, 'Phone', Icons.phone,
                             keyboard: TextInputType.phone),

--- a/lib/presentation/screens/registration/registration_client_screen.dart
+++ b/lib/presentation/screens/registration/registration_client_screen.dart
@@ -383,90 +383,34 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
     );
   }
 
-  /// Gender selection with icon buttons for Male and Female.
-  Widget _buildGenderSelection() {
-    final theme = Theme.of(context);
-    return Center(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
+  Widget _genderChip(String value, IconData icon, Color activeColor) {
+    final selected = _gender == value;
+    return ChoiceChip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          //const Text("Gender: "),
-          const SizedBox(width: 12),
-          GestureDetector(
-            onTap: () {
-              setState(() {
-                _gender = "Male";
-              });
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-              decoration: BoxDecoration(
-                color: _gender == "Male"
-                    ? theme.colorScheme.primary.withOpacity(0.2)
-                    : Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: _gender == "Male"
-                      ? theme.colorScheme.primary
-                      : Colors.grey,
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.male,
-                      color: _gender == "Male"
-                          ? theme.colorScheme.primary
-                          : Colors.grey),
-                  const SizedBox(width: 8),
-                  Text("Male",
-                      style: TextStyle(
-                          color: _gender == "Male"
-                              ? theme.colorScheme.primary
-                              : Colors.grey)),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(width: 16),
-          GestureDetector(
-            onTap: () {
-              setState(() {
-                _gender = "Female";
-              });
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-              decoration: BoxDecoration(
-                color: _gender == "Female"
-                    ? theme.colorScheme.primary.withOpacity(0.2)
-                    : Colors.transparent,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: _gender == "Female"
-                      ? theme.colorScheme.primary
-                      : Colors.grey,
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.female,
-                      color: _gender == "Female"
-                          ? theme.colorScheme.primary
-                          : Colors.grey),
-                  const SizedBox(width: 8),
-                  Text("Female",
-                      style: TextStyle(
-                          color: _gender == "Female"
-                              ? theme.colorScheme.primary
-                              : Colors.grey)),
-                ],
-              ),
-            ),
-          ),
+          Icon(icon, color: selected ? Colors.white : activeColor),
+          const SizedBox(width: 6),
+          Text(value)
         ],
       ),
+      selected: selected,
+      onSelected: (_) => setState(() => _gender = value),
+      selectedColor: activeColor,
+      backgroundColor: Colors.grey.shade200,
+      labelStyle: TextStyle(color: selected ? Colors.white : activeColor),
+    );
+  }
+
+  /// Gender selection using colorful chips.
+  Widget _buildGenderSelection() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _genderChip('Male', Icons.male, Colors.blue),
+        const SizedBox(width: 16),
+        _genderChip('Female', Icons.female, Colors.pink),
+      ],
     );
   }
 
@@ -482,7 +426,8 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
       appBar: GradientAppBar(
         title: 'Registration',
       ),
-      body: Center(        child: SingleChildScrollView(
+      body: Center(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.only(bottom: kScreenBottomPadding),
           child: Column(
             children: [
@@ -505,9 +450,10 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                           // ---------------------------------------------------
                           // Name + Surname
                           // ---------------------------------------------------
-                          Row(
-                            children: [
-                              Expanded(
+                          LayoutBuilder(
+                            builder: (context, constraints) {
+                              final wide = constraints.maxWidth > 360;
+                              final nameField = Expanded(
                                 child: TextField(
                                   controller: _nameController,
                                   decoration: InputDecoration(
@@ -521,9 +467,8 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                                     ),
                                   ),
                                 ),
-                              ),
-                              const SizedBox(width: 16),
-                              Expanded(
+                              );
+                              final surnameField = Expanded(
                                 child: TextField(
                                   controller: _surnameController,
                                   decoration: InputDecoration(
@@ -537,8 +482,24 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                                     ),
                                   ),
                                 ),
-                              ),
-                            ],
+                              );
+                              if (wide) {
+                                return Row(
+                                  children: [
+                                    nameField,
+                                    const SizedBox(width: 16),
+                                    surnameField,
+                                  ],
+                                );
+                              }
+                              return Column(
+                                children: [
+                                  nameField,
+                                  const SizedBox(height: 16),
+                                  surnameField,
+                                ],
+                              );
+                            },
                           ),
                           const SizedBox(height: 16),
 
@@ -676,11 +637,29 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                           // Phone
                           Row(children: [
                             Expanded(
-                              flex: 2, // Takes 2/5 of the available space
-                              child: DropdownButton2<String>(
+                              flex: 2,
+                              child: DropdownButtonFormField2<String>(
                                 value: _selectedCountryCode,
-                                hint: const Text('Prefix'),
-                                isExpanded: true,
+                                decoration: InputDecoration(
+                                  labelText: 'Prefix',
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  prefixIcon: Padding(
+                                    padding: const EdgeInsets.all(10),
+                                    child: Text(
+                                      countryCodes
+                                          .firstWhere(
+                                              (c) =>
+                                                  c['code'] ==
+                                                  _selectedCountryCode,
+                                              orElse: () =>
+                                                  {'flag': '🌐'})['flag']!
+                                          .toString(),
+                                      style: const TextStyle(fontSize: 18),
+                                    ),
+                                  ),
+                                ),
                                 items: [
                                   for (final c in countryCodes)
                                     DropdownMenuItem(
@@ -694,28 +673,15 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                                       ]),
                                     ),
                                 ],
-                                selectedItemBuilder: (ctx) =>
-                                    countryCodes.map((c) {
-                                  return Row(
-                                    children: [
-                                      Text(c['flag']!,
-                                          style: const TextStyle(fontSize: 18)),
-                                      const SizedBox(width: 6),
-                                      Text(c['code']!),
-                                    ],
-                                  );
-                                }).toList(),
                                 onChanged: (v) =>
                                     setState(() => _selectedCountryCode = v),
-                                buttonStyleData:
-                                    const ButtonStyleData(height: 48),
                                 dropdownStyleData:
                                     DropdownStyleData(width: 250),
                               ),
                             ),
                             const SizedBox(width: 16),
                             Expanded(
-                              flex: 3, // Takes 3/5 of the available space
+                              flex: 3,
                               child: _textField(
                                   _phoneController, 'Phone', Icons.phone,
                                   keyboard: TextInputType.phone),
@@ -820,28 +786,35 @@ class _RegisterClientScreenState extends State<RegisterClientScreen> {
                           // ---------------------------------------------------
                           Row(
                             children: [
-                              Expanded(
-                                child: RadioListTile<bool>(
-                                  title: const Text("Go SOLO"),
-                                  value: true,
-                                  groupValue: isSolo,
-                                  onChanged: (value) {
-                                    setState(() {
-                                      isSolo = value ?? true;
-                                    });
-                                  },
-                                ),
+                              ChoiceChip(
+                                label: const Text('Go SOLO'),
+                                selected: isSolo,
+                                onSelected: (_) =>
+                                    setState(() => isSolo = true),
                               ),
-                              Expanded(
-                                child: RadioListTile<bool>(
-                                  title: const Text("Assign PT"),
-                                  value: false,
-                                  groupValue: isSolo,
-                                  onChanged: (value) {
-                                    setState(() {
-                                      isSolo = value ?? false;
-                                    });
-                                  },
+                              const SizedBox(width: 8),
+                              ChoiceChip(
+                                label: const Text('Assign PT'),
+                                selected: !isSolo,
+                                onSelected: (_) =>
+                                    setState(() => isSolo = false),
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.info_outline),
+                                onPressed: () => showDialog(
+                                  context: context,
+                                  builder: (_) => AlertDialog(
+                                    title: const Text('Assign PT'),
+                                    content: const Text(
+                                        'Choosing Assign PT lets you connect with your personal trainer. '
+                                        'Go SOLO to use the app without linking to a trainer.'),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () => Navigator.pop(context),
+                                        child: const Text('Close'),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ],


### PR DESCRIPTION
## Summary
- use responsive layout for name/surname fields
- style gender selection with colorful chips
- provide info dialog for Assign PT choice
- decorate phone prefix field with border and flag icon

## Testing
- `dart format lib/presentation/screens/registration/registration_client_screen.dart lib/presentation/screens/registration/registration_PT_screen.dart`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_686170a0105c832da61e09fd6a7b9cab